### PR TITLE
[#1] Adds support for injecting xRay implementations into daemon

### DIFF
--- a/daemon/conn/xray_client.go
+++ b/daemon/conn/xray_client.go
@@ -30,8 +30,8 @@ type XRay interface {
 	PutTelemetryRecords(input *xray.PutTelemetryRecordsInput) (*xray.PutTelemetryRecordsOutput, error)
 }
 
-// XRayClient represents X-Ray client.
-type XRayClient struct {
+// xRayClient represents X-Ray client.
+type xRayClient struct {
 	xRay *xray.XRay
 }
 
@@ -41,12 +41,12 @@ func GetVersionNumber() string {
 }
 
 // PutTraceSegments makes PutTraceSegments api call on X-Ray client.
-func (c XRayClient) PutTraceSegments(input *xray.PutTraceSegmentsInput) (*xray.PutTraceSegmentsOutput, error) {
+func (c xRayClient) PutTraceSegments(input *xray.PutTraceSegmentsInput) (*xray.PutTraceSegmentsOutput, error) {
 	return c.xRay.PutTraceSegments(input)
 }
 
 // PutTelemetryRecords makes PutTelemetryRecords api call on X-Ray client.
-func (c XRayClient) PutTelemetryRecords(input *xray.PutTelemetryRecordsInput) (*xray.PutTelemetryRecordsOutput, error) {
+func (c xRayClient) PutTelemetryRecords(input *xray.PutTelemetryRecordsInput) (*xray.PutTelemetryRecordsOutput, error) {
 	return c.xRay.PutTelemetryRecords(input)
 }
 
@@ -75,7 +75,7 @@ func requestXray(awsConfig *aws.Config, s *session.Session) XRay {
 	}
 	x.Handlers.Build.PushBackNamed(XRayVersionUserAgentHandler)
 
-	xRay := XRayClient{
+	xRay := xRayClient{
 		xRay: x,
 	}
 	return xRay

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -190,13 +190,19 @@ func initDaemon(config *cfg.Config) *Daemon {
 	// If calculated number of buffer is lower than our default, use calculated one. Otherwise, use default value.
 	parameterConfig.Processor.BatchSize = util.GetMinIntValue(parameterConfig.Processor.BatchSize, bufferLimit)
 
+	x := conn.NewXRay(awsConfig, session)
+	if x == nil {
+		log.Error("X-Ray client returned nil")
+		os.Exit(1)
+	}
+
 	daemon := &Daemon{
 		done:      make(chan bool),
 		std:       std,
 		pool:      bufferPool,
 		count:     0,
 		sock:      sock,
-		processor: processor.New(awsConfig, session, processorCount, std, bufferPool, parameterConfig),
+		processor: processor.New(x, processorCount, std, bufferPool, parameterConfig),
 	}
 
 	return daemon

--- a/daemon/processor/processor.go
+++ b/daemon/processor/processor.go
@@ -20,13 +20,9 @@ import (
 	"github.com/aws/aws-xray-daemon/daemon/tracesegment"
 
 	"math/rand"
-	"os"
 	"github.com/aws/aws-xray-daemon/daemon/cfg"
 	"github.com/aws/aws-xray-daemon/daemon/conn"
 	"github.com/aws/aws-xray-daemon/daemon/util/timer"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // Processor buffers segments and send to X-Ray service.
@@ -63,7 +59,7 @@ type Processor struct {
 }
 
 // New creates new instance of Processor.
-func New(awsConfig *aws.Config, s *session.Session, segmentBatchProcessorCount int, std *ringbuffer.RingBuffer,
+func New(x conn.XRay, segmentBatchProcessorCount int, std *ringbuffer.RingBuffer,
 	pool *bufferpool.BufferPool, c *cfg.ParameterConfig) *Processor {
 	batchesChan := make(chan []*string, c.Processor.BatchProcessorQueueSize)
 	segmentBatchDoneChan := make(chan bool)
@@ -72,11 +68,6 @@ func New(awsConfig *aws.Config, s *session.Session, segmentBatchProcessorCount i
 		done:    segmentBatchDoneChan,
 		randGen: rand.New(rand.NewSource(time.Now().UnixNano())),
 		timer:   &timer.Client{},
-	}
-	x := conn.NewXRay(awsConfig, s)
-	if x == nil {
-		log.Error("X-Ray client returned nil")
-		os.Exit(1)
 	}
 	tsb.xRay = x
 	doneChan := make(chan bool)


### PR DESCRIPTION
One step/trial on #1 

This PR creates the processor early so it can be injected into the daemon. This will allow us to use different `XRay` exporters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Ping @abhiksingh 
