### PR TITLE
Create session using NewSessionWithOptions

### DIFF
--- a/daemon/conn/conn.go
+++ b/daemon/conn/conn.go
@@ -178,7 +178,9 @@ func (c *Conn) newAWSSession(roleArn string) *session.Session {
 }
 
 func getDefaultSession() *session.Session {
-	result, serr := session.NewSession()
+	result, serr := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if serr != nil {
 		log.Errorf("Error in creating session object : %v\n.", serr)
 		os.Exit(1)


### PR DESCRIPTION
*Description of changes:*
Enable shared config when creating session.
https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-local.html seems to indicate that daemon will honor environment variables. This change will allow it to honor the `AWS_PROFILE` variable from a machine with `~/.aws/credentials` and `~/.aws/config` .  Another fix would be just to update documentation to mention the `AWS_SDK_LOAD_CONFIG` in the daemon documentation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
