### PR TITLE
Add section in readme to note it uses the aws-sdk-go and hence honors…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ You can also use [Glide](https://github.com/Masterminds/glide) to manage depende
 ```  
 glide install  
 ```  
+
+## Configuration  
+
+The Aws X-Ray Daemon follows default credential resolution for the [aws-sdk-go](https://docs.aws.amazon.com/sdk-for-go/api/index.html).
+
+Follow the guidelines [here](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) to configure an IAM role for the AWS X-Ray Daemon to run under.
+
 ## Daemon Usage (command line args)  
 
 Usage: X-Ray [options]   


### PR DESCRIPTION
… the AWS_SDK_LOAD_CONFIG variable

*Description of changes:*
This is just adding mention to the readme about how to configure IAM roles for the daemon. This should be pretty straight forward to anyone looking at the repo and who has worked with the aws_sdk_go. This is mostly because other closed source documentation sources like [this](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-local.html) make mention of default credential resolutions, without making it clear that it is the go sdk default, not the broader [default](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html) . 

This method addresses the concerns in https://github.com/aws/aws-xray-daemon/pull/19
without changing the behavior of the daemon itself. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
