### PR TITLE
Do not fail when cleaning build folder

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,4 +91,4 @@ fmt:
 .PHONY: clean-folder
 clean-folder:
 	cd build && \
-	find . ! -name "xray" ! -name "." -type d -exec rm -rf {} +
+	find . ! -name "xray" ! -name "." -type d -exec rm -rf {} + || true


### PR DESCRIPTION
*Description of changes:*
We try our best to clean up the build folder but do not fail if any delete fails, so we don't block the live builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
