### PR TITLE
Support for fetching region from ECS metadata

### DIFF
--- a/daemon/conn/conn.go
+++ b/daemon/conn/conn.go
@@ -112,18 +112,18 @@ func getRegionFromECSMetadata() string {
 	var err error
 	var region string
 	region = ""
-	ecsMetadataEnabled := os.Getenv("ECS_ENABLE_CONTAINER_METADATA")
-	ecsMetadataEnabled := strings.ToLower(ecsMetadataEnabled)
+	ecsMetadataEnabled = os.Getenv("ECS_ENABLE_CONTAINER_METADATA")
+	ecsMetadataEnabled = strings.ToLower(ecsMetadataEnabled)
 	if ecsMetadataEnabled == "true" {
-		metadataFilePath := os.Getenv("ECS_CONTAINER_METADATA_FILE")
-		metadataFile, err := ioutil.ReadFile(metadataFilePath)
+		metadataFilePath = os.Getenv("ECS_CONTAINER_METADATA_FILE")
+		metadataFile, err = ioutil.ReadFile(metadataFilePath)
 		if err != nil {
 			log.Errorf("Unable to open ECS metadata file: %v\n", err)
 		} else {
 			if err := json.Unmarshal(metadataFile, &dat); err != nil {
 				log.Errorf("Unable to read ECS metadatafile contents: %v", err)
 			} else {
-				taskArn := strings.Split(dat["TaskARN"].(string), ":")
+				taskArn = strings.Split(dat["TaskARN"].(string), ":")
 				region = taskArn[3]
 				log.Debugf("Fetch region %v from ECS metadata file", region)
 			}
@@ -150,6 +150,7 @@ func GetAWSConfigSession(cn connAttr, c *cfg.Config, roleArn string, region stri
 		awsRegion, err = cn.getEC2Region(es)
 		if err != nil {
 			log.Errorf("Unable to retrieve the region from the EC2 instance %v\n", err)
+			awsRegion = getRegionFromECSMetadata()
 		} else {
 			log.Debugf("Fetch region %v from ec2 metadata", awsRegion)
 		}

--- a/daemon/conn/conn.go
+++ b/daemon/conn/conn.go
@@ -149,14 +149,13 @@ func GetAWSConfigSession(cn connAttr, c *cfg.Config, roleArn string, region stri
 		es := getDefaultSession()
 		awsRegion, err = cn.getEC2Region(es)
 		if err != nil {
-			log.Errorf("Unable to retrieve the region from the EC2 instance %v\n", err)
 			awsRegion = getRegionFromECSMetadata()
 		} else {
 			log.Debugf("Fetch region %v from ec2 metadata", awsRegion)
 		}
 	}
 	if awsRegion == "" {
-		log.Error("Cannot fetch region variable from config file, environment variables and ec2 metadata.")
+		log.Error("Cannot fetch region variable from config file, environment variables, ec2 metadata, and ecs metadata.")
 		os.Exit(1)
 	}
 	s = cn.newAWSSession(roleArn, awsRegion)

--- a/daemon/conn/conn_test.go
+++ b/daemon/conn/conn_test.go
@@ -16,6 +16,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"log"
+	"bytes"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-xray-daemon/daemon/util/test"
@@ -30,10 +32,31 @@ import (
 )
 
 var ec2Region = "us-east-1"
+var tstFileName = "test_config.json"
+var tstFilePath string
 
 type mockConn struct {
 	mock.Mock
 	sn *session.Session
+}
+
+func setupTestFile(cnfg string) (string, error) {
+	goPath := os.Getenv("PWD")
+	if goPath == "" {
+		panic("GOPATH not set")
+	}
+	tstFilePath = goPath + "/" + tstFileName
+	f, err := os.Create(tstFilePath)
+	if err != nil {
+		panic(err)
+	}
+	f.WriteString(cnfg)
+	f.Close()
+	return goPath, err
+}
+
+func clearTestFile() {
+	os.Remove(tstFilePath)
 }
 
 func (c *mockConn) getEC2Region(s *session.Session) (string, error) {
@@ -128,6 +151,95 @@ func TestNoRegion(t *testing.T) {
 	if e, ok := error.(*exec.ExitError); !ok || e.Success() {
 		t.Fatalf("Process ran with err %v, want exit status 1", error)
 	}
+}
+
+// getRegionFromECSMetadata() returns a valid region from an appropriate JSON file
+func TestValidECSRegion(t *testing.T) {
+	metadataFile :=
+		`{
+    "Cluster": "default",
+    "ContainerInstanceARN": "arn:aws:ecs:us-west-2:012345678910:container-instance/default/1f73d099-b914-411c-a9ff-81633b7741dd",
+    "TaskARN": "arn:aws:ecs:us-west-2:012345678910:task/default/2b88376d-aba3-4950-9ddf-bcb0f388a40c",
+    "TaskDefinitionFamily": "console-sample-app-static",
+    "TaskDefinitionRevision": "1",
+    "ContainerID": "aec2557997f4eed9b280c2efd7afccdcedfda4ac399f7480cae870cfc7e163fd",
+    "ContainerName": "simple-app",
+    "DockerContainerName": "/ecs-console-sample-app-static-1-simple-app-e4e8e495e8baa5de1a00",
+    "ImageID": "sha256:2ae34abc2ed0a22e280d17e13f9c01aaf725688b09b7a1525d1a2750e2c0d1de",
+    "ImageName": "httpd:2.4",
+    "PortMappings": [
+        {
+            "ContainerPort": 80,
+            "HostPort": 80,
+            "BindIp": "0.0.0.0",
+            "Protocol": "tcp"
+        }
+    ],
+    "Networks": [
+        {
+            "NetworkMode": "bridge",
+            "IPv4Addresses": [
+                "192.0.2.0"
+            ]
+        }
+    ],
+    "MetadataFileStatus": "READY",
+    "AvailabilityZone": "us-east-1b",
+    "HostPrivateIPv4Address": "192.0.2.0",
+    "HostPublicIPv4Address": "203.0.113.0"
+}`
+	setupTestFile(metadataFile)
+	os.Setenv("ECS_ENABLE_CONTAINER_METADATA", "true")
+	os.Setenv("ECS_CONTAINER_METADATA_FILE", tstFilePath)
+	testString := getRegionFromECSMetadata()
+
+	assert.EqualValues(t, testString, "us-east-1")
+	clearTestFile()
+}
+
+// getRegionFromECSMetadata() returns an empty string if ECS metadata related env is not set
+func TestNoECSMetadata(t *testing.T){
+	os.Clearenv()
+
+	testString := getRegionFromECSMetadata()
+
+	assert.EqualValues(t, testString, "")
+}
+
+// getRegionFromECSMetadata() throws an error and returns an empty string when ECS metadata file cannot be parsed as valid JSON
+func TestInvalidECSMetadata(t *testing.T){
+	metadataFile := `][foobar})(`
+	setupTestFile(metadataFile)
+	os.Setenv("ECS_ENABLE_CONTAINER_METADATA", "true")
+	os.Setenv("ECS_CONTAINER_METADATA_FILE", tstFilePath)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+	testString := getRegionFromECSMetadata()
+
+	assert.EqualValues(t, testString, "")
+	assert.Contains(t, buf, "Unable to read")
+
+	clearTestFile()
+}
+// getRegionFromECSMetadata() throws an error and returns an empty string when ECS metadata file cannot be opened
+func TestMissingECSMetadataFile(t *testing.T){
+	setupTestFile("")
+	os.Setenv("ECS_ENABLE_CONTAINER_METADATA", "true")
+	os.Setenv("ECS_CONTAINER_METADATA_FILE", tstFilePath)
+	clearTestFile()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+
+	}()
+	testString := getRegionFromECSMetadata()
+
+	assert.EqualValues(t, testString, "")
+	assert.Contains(t, buf, "Unable to open")
 }
 
 // getEC2Region() returns nil region and error, resulting in exiting the process

--- a/daemon/conn/conn_test.go
+++ b/daemon/conn/conn_test.go
@@ -158,8 +158,8 @@ func TestValidECSRegion(t *testing.T) {
 	metadataFile :=
 		`{
     "Cluster": "default",
-    "ContainerInstanceARN": "arn:aws:ecs:us-west-2:012345678910:container-instance/default/1f73d099-b914-411c-a9ff-81633b7741dd",
-    "TaskARN": "arn:aws:ecs:us-west-2:012345678910:task/default/2b88376d-aba3-4950-9ddf-bcb0f388a40c",
+    "ContainerInstanceARN": "arn:aws:ecs:us-east-1:012345678910:container-instance/default/1f73d099-b914-411c-a9ff-81633b7741dd",
+    "TaskARN": "arn:aws:ecs:us-east-1:012345678910:task/default/2b88376d-aba3-4950-9ddf-bcb0f388a40c",
     "TaskDefinitionFamily": "console-sample-app-static",
     "TaskDefinitionRevision": "1",
     "ContainerID": "aec2557997f4eed9b280c2efd7afccdcedfda4ac399f7480cae870cfc7e163fd",

--- a/daemon/conn/conn_test.go
+++ b/daemon/conn/conn_test.go
@@ -195,6 +195,7 @@ func TestValidECSRegion(t *testing.T) {
 
 	assert.EqualValues(t, testString, "us-east-1")
 	clearTestFile()
+	os.Clearenv()
 }
 
 // getRegionFromECSMetadata() returns an empty string if ECS metadata related env is not set


### PR DESCRIPTION
*Issue #, if available:*
40

*Description of changes:*
Added ECS metadata as a fallback option for getting the region when EC2 metadata is unavailable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
