### PR TITLE
Don't leak customer traces at default log level

### DIFF
--- a/pkg/processor/batchprocessor.go
+++ b/pkg/processor/batchprocessor.go
@@ -93,9 +93,9 @@ func (s *segmentsBatch) poll() {
 			for _, unprocessedSegment := range r.UnprocessedTraceSegments {
 				telemetry.T.SegmentRejected(1)
 				log.Errorf("Unprocessed segment: %v", unprocessedSegment)
-				log.Warn("Batch that contains unprocessed segments")
+				log.Debug("Batch that contains unprocessed segments")
 				for i := 0; i < len(batch); i++ {
-					log.Warn(*batch[i])
+					log.Debug(*batch[i])
 				}
 			}
 		} else {


### PR DESCRIPTION
Logging dropped segments at 'warn' level leaks customer data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
