### PR TITLE
not print `successfully` if there are Unprocessed segments

### DIFF
--- a/pkg/processor/batchprocessor.go
+++ b/pkg/processor/batchprocessor.go
@@ -89,14 +89,20 @@ func (s *segmentsBatch) poll() {
 				telemetry.T.SegmentSent(int64(len(batch)))
 			}
 			elapsed := time.Since(start)
-			log.Infof("Successfully sent batch of %d segments (%1.3f seconds)", len(batch), elapsed.Seconds())
-			for _, unprocessedSegment := range r.UnprocessedTraceSegments {
-				telemetry.T.SegmentRejected(1)
-				log.Errorf("Unprocessed segment: %v", unprocessedSegment)
-				log.Debug("Batch that contains unprocessed segments")
-				for i := 0; i < len(batch); i++ {
-					log.Debug(*batch[i])
+
+			if len(r.UnprocessedTraceSegments) != 0 {
+				log.Infof("Sent batch of %d segments but had %d Unprocessed segments (%1.3f seconds)", len(batch),
+					len(r.UnprocessedTraceSegments), elapsed.Seconds())
+				for _, unprocessedSegment := range r.UnprocessedTraceSegments {
+					telemetry.T.SegmentRejected(1)
+					log.Errorf("Unprocessed segment: %v", unprocessedSegment)
+					log.Debug("Batch that contains unprocessed segments")
+					for i := 0; i < len(batch); i++ {
+						log.Debug(*batch[i])
+					}
 				}
+			} else {
+				log.Infof("Successfully sent batch of %d segments (%1.3f seconds)", len(batch), elapsed.Seconds())
 			}
 		} else {
 			log.Debug("Segment batch: done!")

--- a/pkg/processor/batchprocessor_test.go
+++ b/pkg/processor/batchprocessor_test.go
@@ -309,7 +309,7 @@ func TestPoolSendReturnUnprocessed(t *testing.T) {
 	<-s.done
 
 	assert.EqualValues(t, xRay.CallNoToPutTraceSegments, 1)
-	assert.True(t, strings.Contains(log.Logs[0], fmt.Sprintf("Successfully sent batch of %v", 1)))
+	assert.True(t, strings.Contains(log.Logs[0], fmt.Sprintf("Sent batch of %v segments but had %v Unprocessed segments", 1, 1)) )
 	assert.True(t, strings.Contains(log.Logs[1], "Unprocessed segment"))
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/63

*Description of changes:*
If part of segments break the x-ray rules like invalid ID, at present the log is:
```
2020-08-11T22:59:59-07:00 [Info] Successfully sent batch of 2 segments (0.064 seconds)
```

This fix improves log detail, if there are Unprocessed segments returned, print:
```
2020-08-11T23:00:15-07:00 [Info] Sent batch of 2 segments but had 1 Unprocessed segments (0.080 seconds)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
