### PR TITLE
debug logging print only unprocessed segments detail

### DIFF
--- a/pkg/processor/batchprocessor.go
+++ b/pkg/processor/batchprocessor.go
@@ -12,6 +12,7 @@ package processor
 import (
 	"math"
 	"math/rand"
+	"strings"
 	"time"
 	"github.com/aws/aws-xray-daemon/pkg/conn"
 	"github.com/aws/aws-xray-daemon/pkg/telemetry"
@@ -96,10 +97,11 @@ func (s *segmentsBatch) poll() {
 				for _, unprocessedSegment := range r.UnprocessedTraceSegments {
 					telemetry.T.SegmentRejected(1)
 					log.Errorf("Unprocessed segment: %v", unprocessedSegment)
-				}
-				log.Debug("Batch that contains unprocessed segments")
-				for i := 0; i < len(batch); i++ {
-					log.Debug(*batch[i])
+					for i := 0; i < len(batch); i++ {
+						if strings.Contains(*batch[i], "\"id\":\"" + *unprocessedSegment.Id) {
+							log.Debug(*batch[i])
+						}
+					}
 				}
 			} else {
 				log.Infof("Successfully sent batch of %d segments (%1.3f seconds)", len(batch), elapsed.Seconds())

--- a/pkg/processor/batchprocessor_test.go
+++ b/pkg/processor/batchprocessor_test.go
@@ -300,7 +300,7 @@ func TestPoolSendReturnUnprocessed(t *testing.T) {
 		xRay:    xRay,
 		done:    make(chan bool),
 	}
-	testMessage := "Test Message"
+	testMessage := "{\"id\":\"9472\""
 	batch := []*string{&testMessage}
 	s.send(batch)
 

--- a/pkg/processor/batchprocessor_test.go
+++ b/pkg/processor/batchprocessor_test.go
@@ -97,7 +97,7 @@ func TestPollSendSuccess(t *testing.T) {
 		xRay:    xRay,
 		done:    make(chan bool),
 	}
-	testMessage := "Test Message"
+	testMessage := "{\"id\":\"9472\""
 	batch := []*string{&testMessage}
 	s.send(batch)
 
@@ -271,7 +271,7 @@ func TestPutTraceSegmentsParameters(t *testing.T) {
 		xRay:    xRay,
 		done:    make(chan bool),
 	}
-	testMessage := "Test Message"
+	testMessage := "{\"id\":\"9472\""
 	batch := []*string{&testMessage}
 	s.send(batch)
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/63

*Description of changes:*
Only log unprocessed segments by comparing the IDs.
Here because batches is a string slice, filter the unprocessed segments by matching string 'id' will get complexity O(m*n). 
To reduce the complexity we create a map for batches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
