### PR TITLE
GitHub actions continuous build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+.git
+.dockerignore
+Dockerfile
+
+*.md
+
+bin
+test_coverage
+build
+.idea
+.DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+vendor

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -56,6 +56,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
+          platforms: linux/amd64,linux/arm64
           tags: amazon/aws-xray-daemon:alpha
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,8 +1,8 @@
 name: Continuous Build
 on:
   push:
-    #branches:
-    #  - master
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,61 @@
+name: Continuous Build
+on:
+  push:
+    #branches:
+    #  - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        run: go test -cover ./...
+      - name: Build daemon
+        run: go build ./cmd/tracing/daemon.go ./cmd/tracing/tracing.go
+  build_docker:
+    name: Build for ${{ matrix.os }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: amazon/aws-xray-daemon:alpha
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Run tests
         run: go test -cover ./...
       - name: Build daemon
-        run: go build ./cmd/tracing/daemon.go ./cmd/tracing/tracing.go
+        run: go build ./cmd/tracing
   build_docker:
-    name: Build for ${{ matrix.os }}
+    name: Build Docker image
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ install:
 script:
   - make test
 
-deploy:
-  provider: script
-  script: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && make build-docker && make push-docker
-  on:
-    tags: true
-
 matrix:
   allow_failures:
     - go: tip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
 # build stage
-FROM golang:1.13-alpine AS build-env
+FROM golang:1.15-alpine AS build-env
 
-RUN apk update && apk add git ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates
 
-RUN mkdir -p /go/src/github.com/aws/aws-xray-daemon
-WORKDIR /go/src/github.com/aws/aws-xray-daemon
+WORKDIR /workspace
 
 COPY go.mod .
 COPY go.sum .
 
 RUN go mod download
 
-COPY  . .
+COPY . .
+
 RUN adduser -D -u 10001 xray
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' \
-    -o daemon ./cmd/tracing/daemon.go ./cmd/tracing/tracing.go
+    -o xray ./cmd/tracing
 
 FROM scratch
-COPY --from=build-env /go/src/github.com/aws/aws-xray-daemon/daemon .
+COPY --from=build-env /workspace/xray .
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
 USER xray
-ENTRYPOINT ["/daemon"]
+ENTRYPOINT ["/xray"]

--- a/cmd/tracing/tracing.go
+++ b/cmd/tracing/tracing.go
@@ -7,6 +7,8 @@
 // or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+// +build !windows
+
 package main
 
 import (

--- a/cmd/tracing/tracing_windows.go
+++ b/cmd/tracing/tracing_windows.go
@@ -7,6 +7,8 @@
 // or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+// +build windows
+
 package main
 
 import (


### PR DESCRIPTION
This adds a GitHub actions continuous build that builds on the three main OS's and a Docker image. In a follow up PR, we can also set up creds and have it pushing to Docker Hub. In a similar follow up PR we can remove the Travis build too.

Currently, the published Docker Hub image has cgo enabled. cgo is mostly needed when using other c libraries, and otherwise may provide better DNS resolutions on not-so-well supported platforms, but on the major OSs it's basically not needed. OTel collector also doesn't use it to make building easier. So instead, we get a statically linked binary suitable for the scratch docker base image. This will be a good default for our next release.

I also removed a deployment section from travis, it hasn't been used yet and presumably we don't want to push docker images from Travis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
