### PR TITLE
Revert "Support credential profiles"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,12 @@ Usage: X-Ray [options]
 5. -b  --bind    Overrides default UDP address (127.0.0.1:2000).  
 6. -t  --bind-tcp	Overrides default TCP address (127.0.0.1:2000).  
 7. -r  --role-arn Assume the specified IAM role to upload segments to a different account.    
-8. -s  --profile Use the credentials associated with the specified profile.
-9. -c  --config   Load a configuration file from the specified path.    
-10. -f  --log-file Output logs to the specified file path.    
-11. -l  --log-level    Log level, from most verbose to least: dev, debug, info, warn, error, prod (default).    
-12. -p --proxy-address  Proxy address through which to upload segments.
-13. -v --version  Show AWS X-Ray daemon version.
-14. -h --help    Show this screen
+8. -c  --config   Load a configuration file from the specified path.    
+9. -f  --log-file Output logs to the specified file path.    
+10. -l  --log-level    Log level, from most verbose to least: dev, debug, info, warn, error, prod (default).    
+11. -p --proxy-address  Proxy address through which to upload segments.
+12. -v --version  Show AWS X-Ray daemon version.
+13. -h --help    Show this screen
 
 ## Build  
 

--- a/cmd/tracing/daemon.go
+++ b/cmd/tracing/daemon.go
@@ -56,7 +56,6 @@ var socketConnection string
 var cpuProfile string
 var memProfile string
 var roleArn string
-var profile string
 var receiveBufferSize int
 var daemonProcessBufferMemoryMB int
 var logFile string
@@ -122,7 +121,6 @@ func initCli(configFile string) (*cli.Flag, *cfg.Config) {
 		defaultUDPAddress                = cnfg.Socket.UDPAddress
 		defaultTCPAddress                = cnfg.Socket.TCPAddress
 		defaultRoleARN                   = cnfg.RoleARN
-		defaultProfile                   = cnfg.Profile
 		defaultLocalMode                 = cnfg.LocalMode
 		defaultRegion                    = cnfg.Region
 		defaultResourceARN               = cnfg.ResourceARN
@@ -137,7 +135,6 @@ func initCli(configFile string) (*cli.Flag, *cfg.Config) {
 	flag.StringVarF(&udpAddress, "bind", "b", defaultUDPAddress, "Overrides default UDP address (127.0.0.1:2000).")
 	flag.StringVarF(&tcpAddress, "bind-tcp", "t", defaultTCPAddress, "Overrides default TCP address (127.0.0.1:2000).")
 	flag.StringVarF(&roleArn, "role-arn", "r", defaultRoleARN, "Assume the specified IAM role to upload segments to a different account.")
-	flag.StringVarF(&profile, "profile", "s", defaultProfile, "Use the credentials associated with the specified profile.")
 	flag.StringVarF(&configFilePath, "config", "c", "", "Load a configuration file from the specified path.")
 	flag.StringVarF(&logFile, "log-file", "f", defaultLogPath, "Output logs to the specified file path.")
 	flag.StringVarF(&logLevel, "log-level", "l", defaultLogLevel, "Log level, from most verbose to least: dev, debug, info, warn, error, prod (default).")
@@ -195,7 +192,7 @@ func initDaemon(config *cfg.Config) *Daemon {
 	if config.Endpoint != "" {
 		log.Debugf("Using Endpoint read from Config file: %s", config.Endpoint)
 	}
-	awsConfig, session := conn.GetAWSConfigSession(&conn.Conn{}, config, roleArn, profile, regionFlag, noMetadata)
+	awsConfig, session := conn.GetAWSConfigSession(&conn.Conn{}, config, roleArn, regionFlag, noMetadata)
 	log.Infof("Using region: %v", aws.StringValue(awsConfig.Region))
 
 	log.Debugf("ARN of the AWS resource running the daemon: %v", resourceARN)

--- a/pkg/cfg.yaml
+++ b/pkg/cfg.yaml
@@ -23,8 +23,6 @@ LocalMode: false
 ResourceARN: ""
 # Assume an IAM role to upload segments to a different account.
 RoleARN: ""
-# Use the profile credentials from credentials file
-Profile: ""
 # Disable TLS certificate verification.
 NoVerifySSL: false
 # Upload segments to AWS X-Ray through a proxy.

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -85,9 +85,6 @@ type Config struct {
 	// IAM role to upload segments to a different account.
 	RoleARN string `yaml:"RoleARN"`
 
-	// Profile name to use from the credentials file
-	Profile string `yaml:"Profile"`
-
 	// Enable or disable TLS certificate verification.
 	NoVerifySSL *bool `yaml:"NoVerifySSL"`
 
@@ -366,7 +363,6 @@ func merge(configFile string) *Config {
 	userConfig.TotalBufferSizeMB = getIntValue(userConfig.TotalBufferSizeMB, DefaultConfig().TotalBufferSizeMB)
 	userConfig.ResourceARN = getStringValue(userConfig.ResourceARN, DefaultConfig().ResourceARN)
 	userConfig.RoleARN = getStringValue(userConfig.RoleARN, DefaultConfig().RoleARN)
-	userConfig.Profile = getStringValue(userConfig.Profile, DefaultConfig().Profile)
 	userConfig.Concurrency = getIntValue(userConfig.Concurrency, DefaultConfig().Concurrency)
 	userConfig.Endpoint = getStringValue(userConfig.Endpoint, DefaultConfig().Endpoint)
 	userConfig.Region = getStringValue(userConfig.Region, DefaultConfig().Region)

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -606,7 +606,7 @@ Version: 2`
 }
 
 func TestValidConfigArray(t *testing.T) {
-	validString := []string{"TotalBufferSizeMB", "Concurrency", "Endpoint", "Region", "Socket.UDPAddress", "Socket.TCPAddress", "ProxyServer.IdleConnTimeout", "ProxyServer.MaxIdleConnsPerHost", "ProxyServer.MaxIdleConns", "Logging.LogRotation", "Logging.LogLevel", "Logging.LogPath", "LocalMode", "ResourceARN", "RoleARN", "Profile", "NoVerifySSL", "ProxyAddress", "Version"}
+	validString := []string{"TotalBufferSizeMB", "Concurrency", "Endpoint", "Region", "Socket.UDPAddress", "Socket.TCPAddress", "ProxyServer.IdleConnTimeout", "ProxyServer.MaxIdleConnsPerHost", "ProxyServer.MaxIdleConns", "Logging.LogRotation", "Logging.LogLevel", "Logging.LogPath", "LocalMode", "ResourceARN", "RoleARN", "NoVerifySSL", "ProxyAddress", "Version"}
 	testString := validConfigArray()
 	if len(validString) != len(testString) {
 		t.Fatalf("Unexpect test array length. Got %v but should be %v", len(testString), len(validString))


### PR DESCRIPTION
Reverts aws/aws-xray-daemon#76

AWS SDK supports Credential profile by environment variable [`AWS_PROFILE`](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_environment.html), I have verified in my environment. No need this PR.