### PR TITLE
build statically linked binary on linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ build-mac:
 .PHONY: build-linux
 build-linux:
 	@echo "Build for Linux amd64"
-	GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray/xray ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray/xray ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
 
 .PHONY: build-windows
 build-windows:


### PR DESCRIPTION
*Description of changes:*
Adding symbol CGO_ENABLED=0, to build xray daemon Linux statically linked binary. 

Before
```
dev-dsk-wangzl-2c-e7c31da9 % make build-linux
Build for Linux amd64
GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o /local/home/wangzl/workspace/aws-xray-daemon/build/xray/xray ./cmd/tracing/daemon.go ./cmd/tracing/tracing.go

(20-11-03 19:27:05) <0> [~/workspace/aws-xray-daemon]
dev-dsk-wangzl-2c-e7c31da9 % ls -l build/xray/xray
-rwxr-xr-x 1 wangzl amazon 9531392 Nov  3 19:27 build/xray/xray

(20-11-03 19:27:09) <0> [~/workspace/aws-xray-daemon]
dev-dsk-wangzl-2c-e7c31da9 % ldd build/xray/xray
	linux-vdso.so.1 =>  (0x00007fff0d0ed000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f2c10cef000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f2c1095b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2c10f0c000)
``` 

Statically linked binary
```
dev-dsk-wangzl-2c-e7c31da9 % make build-linux
Build for Linux amd64
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o /local/home/wangzl/workspace/aws-xray-daemon/build/xray/xray ./cmd/tracing/daemon.go ./cmd/tracing/tracing.go

(20-11-03 19:20:58) <0> [~/workspace/aws-xray-daemon]
dev-dsk-wangzl-2c-e7c31da9 % ldd build/xray/xray
	not a dynamic executable

(20-11-03 19:21:04) <1> [~/workspace/aws-xray-daemon]
dev-dsk-wangzl-2c-e7c31da9 % ls -l build/xray/xray
-rwxr-xr-x 1 wangzl amazon 9494528 Nov  3 19:20 build/xray/xray
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
