### PR TITLE
add html anchor tag for go sdk credentials configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go get -u github.com/aws/aws-xray-daemon/...
 
 ## Credential Configuration
 
-The AWS X-Ray Daemon follows default credential resolution for the [aws-sdk-go](https://docs.aws.amazon.com/sdk-for-go/api/index.html).
+The AWS X-Ray Daemon follows default credential resolution for the [aws-sdk-go](https://docs.aws.amazon.com/sdk-for-go/api/index.html#hdr-Configuring_Credentials).
 
 Follow the [guidelines](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) for the credential configuration.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/74

*Description of changes:*
AWS go  SDK does support `source_profile` but has to enable it by setting environment `AWS_SDK_LOAD_CONFIG=1`.
Improve user guide to be easily find the document how to set credential configuration in go sdk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
