### PR TITLE
Use prebuilt binaries for docker image too.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ Dockerfile
 
 bin
 test_coverage
-build
 .idea
 .DS_Store
 

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -63,6 +63,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: amazon/aws-xray-daemon:alpha

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -44,7 +44,7 @@ jobs:
           name: distributions
           path: build/dist/
       - name: Login to DockerHub
-        if: ${{ runner.os == 'Linux' && 'github.event_name == 'push' }}
+        if: ${{ runner.os == 'Linux' && github.event_name == 'push' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -43,23 +43,14 @@ jobs:
         with:
           name: distributions
           path: build/dist/
-
-  build_docker:
-    name: Build Docker image
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
       - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ runner.os == 'Linux' && 'github.event_name == 'push' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
+        if: ${{ runner.os == 'Linux' }}
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -69,6 +60,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Build docker image
+        if: ${{ runner.os == 'Linux' }}
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.event_name == 'push' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,10 @@ RUN apk update && apk add ca-certificates
 
 WORKDIR /workspace
 
-COPY go.mod .
-COPY go.sum .
-
-RUN go mod download
-
 COPY . .
 
 RUN adduser -D -u 10001 xray
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' \
-    -o xray ./cmd/tracing
+RUN Tool/src/build-in-docker.sh
 
 FROM scratch
 COPY --from=build-env /workspace/xray .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.15-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.15-alpine AS build-env
 
 RUN apk update && apk add ca-certificates
 

--- a/Tool/src/build-in-docker.sh
+++ b/Tool/src/build-in-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+BUILD_FOLDER=${TARGETPLATFORM/\//-}
+
+if [[ -d "/workspace/build/xray-${BUILD_FOLDER}" ]]; then
+  echo "Copying prebuilt binary"
+  cp /workspace/build/xray-${BUILD_FOLDER}/xray /workspace
+else
+  echo "Building from source"
+  CGO_ENABLED=0 GOOS=linux GOARCH=$(echo $TARGETPLATFORM | cut -d'/' -f2) go build -a -ldflags '-extldflags "-static"' -o /workspace/xray /workspace/cmd/tracing
+fi

--- a/Tool/src/build-in-docker.sh
+++ b/Tool/src/build-in-docker.sh
@@ -5,7 +5,7 @@ BUILD_FOLDER=${TARGETPLATFORM/\//-}
 
 if [[ -d "/workspace/build/xray-${BUILD_FOLDER}" ]]; then
   echo "Copying prebuilt binary"
-  cp /workspace/build/xray-${BUILD_FOLDER}/xray /workspace
+  cp /workspace/build/xray-${BUILD_FOLDER}/xray /workspace/
 else
   echo "Building from source"
   CGO_ENABLED=0 GOOS=linux GOARCH=$(echo $TARGETPLATFORM | cut -d'/' -f2) go build -a -ldflags '-extldflags "-static"' -o /workspace/xray /workspace/cmd/tracing


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates Dockerfile to copy binaries that have already been built if they exist to avoid having multiple ground-truth binaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
