### PR TITLE
Packaging daemon into amd64 and arm64 type rpm

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Build linux archives
         if: ${{ runner.os == 'Linux' }}
         run: make packaging
+        env:
+          VERSION: ${{ github.sha }}
       
       - name: Upload archives as actions artifact
         if: ${{ runner.os == 'Linux' }}

--- a/Tool/src/packaging/linux/build_rpm_linux.sh
+++ b/Tool/src/packaging/linux/build_rpm_linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 ARCH=$1
 if [[ $ARCH == "amd64" ]]
 then
@@ -36,7 +38,7 @@ cp ${BGO_SPACE}/THIRD-PARTY-LICENSES.txt ${BGO_SPACE}/bin/linux_${ARCH}/linux/et
 echo "Creating the rpm package"
 SPEC_FILE="${BGO_SPACE}/Tool/src/packaging/linux/xray.spec"
 BUILD_ROOT="${BGO_SPACE}/bin/linux_${ARCH}/linux"
-setarch ${BUILD_ARCH} rpmbuild --define "rpmversion ${VERSION}" --define "_topdir bin/linux_${ARCH}/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
+rpmbuild --target ${BUILD_ARCH}-linux --define "rpmversion ${VERSION}" --define "_topdir bin/linux_${ARCH}/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
 
 echo "Copying rpm files to bin"
 cp ${BGO_SPACE}/bin/linux_${ARCH}/linux/rpmbuild/RPMS/${BUILD_ARCH}/*.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-${ARCH}-${VERSION}.rpm

--- a/Tool/src/packaging/linux/build_rpm_linux.sh
+++ b/Tool/src/packaging/linux/build_rpm_linux.sh
@@ -1,29 +1,42 @@
 #!/usr/bin/env bash
+
+ARCH=$1
+if [[ $ARCH == "amd64" ]]
+then
+    BUILD_ARCH=x86_64
+elif [[ $ARCH == "arm64" ]]
+then
+    BUILD_ARCH=aarch64
+else
+    echo "Invalid architecture input. Exiting"
+    exit 1
+fi
+
 echo "*************************************************"
-echo "Creating rpm file for Amazon Linux and RHEL amd64"
+echo "Creating rpm file for Amazon Linux and RHEL ${ARCH}"
 echo "*************************************************"
 
-rm -rf ${BGO_SPACE}/bin/linux_amd64/linux
+rm -rf ${BGO_SPACE}/bin/linux_${ARCH}/linux
 
 echo "Creating rpmbuild workspace"
-mkdir -p ${BGO_SPACE}/bin/linux_amd64/linux/rpmbuild/{RPMS,SRPMS,BUILD,COORD_SOURCES,SPECS,DATA_SOURCES}
-mkdir -p ${BGO_SPACE}/bin/linux_amd64/linux/usr/bin/
-mkdir -p ${BGO_SPACE}/bin/linux_amd64/linux/etc/amazon/xray/
-mkdir -p ${BGO_SPACE}/bin/linux_amd64/linux/etc/init/
-mkdir -p ${BGO_SPACE}/bin/linux_amd64/linux/etc/systemd/system/
+mkdir -p ${BGO_SPACE}/bin/linux_${ARCH}/linux/rpmbuild/{RPMS,SRPMS,BUILD,COORD_SOURCES,SPECS,DATA_SOURCES}
+mkdir -p ${BGO_SPACE}/bin/linux_${ARCH}/linux/usr/bin/
+mkdir -p ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/amazon/xray/
+mkdir -p ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/init/
+mkdir -p ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/systemd/system/
 
 echo "Copying application files"
-cp ${BGO_SPACE}/build/xray-linux-amd64/xray ${BGO_SPACE}/bin/linux_amd64/linux/usr/bin/
-cp ${BGO_SPACE}/pkg/cfg.yaml ${BGO_SPACE}/bin/linux_amd64/linux/etc/amazon/xray/cfg.yaml
-cp ${BGO_SPACE}/Tool/src/packaging/linux/xray.conf ${BGO_SPACE}/bin/linux_amd64/linux/etc/init/
-cp ${BGO_SPACE}/Tool/src/packaging/linux/xray.service ${BGO_SPACE}/bin/linux_amd64/linux/etc/systemd/system/
-cp ${BGO_SPACE}/LICENSE ${BGO_SPACE}/bin/linux_amd64/linux/etc/amazon/xray/
-cp ${BGO_SPACE}/THIRD-PARTY-LICENSES.txt ${BGO_SPACE}/bin/linux_amd64/linux/etc/amazon/xray/
+cp ${BGO_SPACE}/build/xray-linux-${ARCH}/xray ${BGO_SPACE}/bin/linux_${ARCH}/linux/usr/bin/
+cp ${BGO_SPACE}/pkg/cfg.yaml ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/amazon/xray/cfg.yaml
+cp ${BGO_SPACE}/Tool/src/packaging/linux/xray.conf ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/init/
+cp ${BGO_SPACE}/Tool/src/packaging/linux/xray.service ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/systemd/system/
+cp ${BGO_SPACE}/LICENSE ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/amazon/xray/
+cp ${BGO_SPACE}/THIRD-PARTY-LICENSES.txt ${BGO_SPACE}/bin/linux_${ARCH}/linux/etc/amazon/xray/
 
 echo "Creating the rpm package"
 SPEC_FILE="${BGO_SPACE}/Tool/src/packaging/linux/xray.spec"
-BUILD_ROOT="${BGO_SPACE}/bin/linux_amd64/linux"
-setarch x86_64 rpmbuild --define "rpmversion ${VERSION}" --define "_topdir bin/linux_amd64/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
+BUILD_ROOT="${BGO_SPACE}/bin/linux_${ARCH}/linux"
+setarch ${BUILD_ARCH} rpmbuild --define "rpmversion ${VERSION}" --define "_topdir bin/linux_${ARCH}/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
 
 echo "Copying rpm files to bin"
-cp ${BGO_SPACE}/bin/linux_amd64/linux/rpmbuild/RPMS/x86_64/*.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm
+cp ${BGO_SPACE}/bin/linux_${ARCH}/linux/rpmbuild/RPMS/${BUILD_ARCH}/*.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-${ARCH}-${VERSION}.rpm

--- a/makefile
+++ b/makefile
@@ -76,7 +76,8 @@ package-deb:
 
 .PHONY: package-rpm
 package-rpm:
-	-$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh
+	$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh amd64
+	$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh arm64
 
 .PHONY: test
 test:


### PR DESCRIPTION
*Description of changes:*
In the previous builds of the CI, the rpm was breaking due to `VERSION` not being set in the environment. Added that. Also modifying the script to build the arm64 type rpm for the daemon.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
