### PR TITLE
adding job to build old name artifacts

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -43,12 +43,6 @@ jobs:
         run: make packaging
         env:
           VERSION: ${{ github.sha }}
-
-      - name: Build legacy archives
-        if: ${{ runner.os == 'Linux' }}
-        run: make build-package-legacy
-        env:
-          VERSION: ${{ github.sha }}
       
       - name: Upload archives as actions artifact
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -43,6 +43,12 @@ jobs:
         run: make packaging
         env:
           VERSION: ${{ github.sha }}
+
+      - name: Build legacy archives
+        if: ${{ runner.os == 'Linux' }}
+        run: make build-package-legacy
+        env:
+          VERSION: ${{ github.sha }}
       
       - name: Upload archives as actions artifact
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -32,6 +32,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
 
       - name: Build linux archives
+        if: ${{ runner.os == 'Linux' }}
         run: make packaging
         env:
           VERSION: ${{ github.event.inputs.version }}

--- a/Tool/src/packaging/build-package-legacy.sh
+++ b/Tool/src/packaging/build-package-legacy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 echo "****************************************"
 echo "Creating legacy artifacts for 3.x with older names"
 echo "****************************************"
@@ -13,14 +16,14 @@ cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm ${BGO_SPAC
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.deb
 
 echo "Building and packaging legacy artifacts for MacOS"
-GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-mac-legacy/xray_mac ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing.go
 cp ${BGO_SPACE}/build/xray-mac-legacy/xray_mac xray_mac
 zip aws-xray-daemon-macos-3.x.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 rm xray_mac
 
 echo "Building and packaging legacy artifacts for Windows"
-GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
-GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray.exe ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing_windows.go
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing.go
 cp ${BGO_SPACE}/build/xray-win-legacy/xray.exe xray.exe
 zip aws-xray-daemon-windows-service-3.x.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 rm xray.exe

--- a/Tool/src/packaging/build-package-legacy.sh
+++ b/Tool/src/packaging/build-package-legacy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+echo "****************************************"
+echo "Creating legacy artifacts for 3.x with older names"
+echo "****************************************"
+
+cd ${BGO_SPACE}/build/dist
+
+echo "Building and packaging legacy artifacts for Linux"
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-3.x.zip
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-3.x.rpm
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-3.x.deb
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.rpm
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.deb
+
+echo "Building and packaging legacy artifacts for MacOS"
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+cp ${BGO_SPACE}/build/xray-mac-legacy/xray_mac xray_mac
+zip aws-xray-daemon-macos-3.x.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray_mac
+
+echo "Building and packaging legacy artifacts for Windows"
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+cp ${BGO_SPACE}/build/xray-win-legacy/xray.exe xray.exe
+zip aws-xray-daemon-windows-service-3.x.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray.exe
+cp ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe xray_windows.exe
+zip aws-xray-daemon-windows-process-3.x.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray_windows.exe
+
+rm cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt

--- a/Tool/src/packaging/build-package-legacy.sh
+++ b/Tool/src/packaging/build-package-legacy.sh
@@ -16,18 +16,19 @@ cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm ${BGO_SPAC
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.deb
 
 echo "Building and packaging legacy artifacts for MacOS"
-GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-mac-legacy/xray_mac ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing.go
-cp ${BGO_SPACE}/build/xray-mac-legacy/xray_mac xray_mac
+unzip -q -o aws-xray-daemon-macos-amd64-${VERSION}.zip
+mv xray xray_mac
 zip aws-xray-daemon-macos-3.x.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 rm xray_mac
 
 echo "Building and packaging legacy artifacts for Windows"
-GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray.exe ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing_windows.go
-GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe ${BGO_SPACE}/cmd/tracing/daemon.go ${BGO_SPACE}/cmd/tracing/tracing.go
-cp ${BGO_SPACE}/build/xray-win-legacy/xray.exe xray.exe
+unzip -q -o aws-xray-daemon-windows-amd64-service-${VERSION}.zip
+mv xray_service.exe xray.exe
 zip aws-xray-daemon-windows-service-3.x.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 rm xray.exe
-cp ${BGO_SPACE}/build/xray-win-legacy/xray_windows.exe xray_windows.exe
+
+unzip -q -o aws-xray-daemon-windows-amd64-${VERSION}.zip
+mv xray.exe xray_windows.exe
 zip aws-xray-daemon-windows-process-3.x.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 rm xray_windows.exe
 

--- a/Tool/src/packaging/debian/build_deb_linux.sh
+++ b/Tool/src/packaging/debian/build_deb_linux.sh
@@ -19,7 +19,7 @@ mkdir -p ${BGO_SPACE}/bin/debian_${ARCH}/debian/usr/share/doc/xray/
 echo "Copying application files"
 
 cp ${BGO_SPACE}/build/xray-linux-${ARCH}/xray ${BGO_SPACE}/bin/debian_${ARCH}/debian/usr/bin/
-cp ${BGO_SPACE}/build/xray/cfg.yaml ${BGO_SPACE}/bin/debian_${ARCH}/debian/etc/amazon/xray/cfg.yaml
+cp ${BGO_SPACE}/build/dist/cfg.yaml ${BGO_SPACE}/bin/debian_${ARCH}/debian/etc/amazon/xray/cfg.yaml
 cp ${BGO_SPACE}/Tool/src/packaging/debian/xray.conf ${BGO_SPACE}/bin/debian_${ARCH}/debian/etc/init/xray.conf
 cp ${BGO_SPACE}/Tool/src/packaging/debian/xray.service ${BGO_SPACE}/bin/debian_${ARCH}/debian/lib/systemd/system/xray.service
 

--- a/Tool/src/packaging/linux/build_zip_linux.sh
+++ b/Tool/src/packaging/linux/build_zip_linux.sh
@@ -6,5 +6,10 @@ echo "****************************************"
 DIST_FOLDER=${BGO_SPACE}/build/dist/
 cd $DIST_FOLDER
 
-zip aws-xray-daemon-linux-amd64-${VERSION}.zip ../xray-linux-amd64/xray ../xray/cfg.yaml ../xray/LICENSE ../xray/THIRD-PARTY-LICENSES.txt
-zip aws-xray-daemon-linux-arm64-${VERSION}.zip ../xray-linux-arm64/xray ../xray/cfg.yaml ../xray/LICENSE ../xray/THIRD-PARTY-LICENSES.txt
+cp ../xray-linux-amd64/xray xray
+zip aws-xray-daemon-linux-amd64-${VERSION}.zip xray cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray
+
+cp ../xray-linux-arm64/xray xray
+zip aws-xray-daemon-linux-arm64-${VERSION}.zip xray cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray

--- a/Tool/src/packaging/osx/build_zip_osx.sh
+++ b/Tool/src/packaging/osx/build_zip_osx.sh
@@ -6,4 +6,6 @@ echo "****************************************"
 DIST_FOLDER=${BGO_SPACE}/build/dist/
 cd $DIST_FOLDER
 
-zip aws-xray-daemon-macos-amd64-${VERSION}.zip ../xray-mac-amd64/xray ../xray/cfg.yaml ../xray/LICENSE ../xray/THIRD-PARTY-LICENSES.txt
+cp ../xray-mac-amd64/xray xray
+zip aws-xray-daemon-macos-amd64-${VERSION}.zip xray cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray

--- a/Tool/src/packaging/windows/build_zip_win.sh
+++ b/Tool/src/packaging/windows/build_zip_win.sh
@@ -6,5 +6,10 @@ echo "****************************************"
 DIST_FOLDER=${BGO_SPACE}/build/dist/
 cd $DIST_FOLDER
 
-zip aws-xray-daemon-windows-amd64-service-${VERSION}.zip ../xray-windows-amd64/xray_service.exe ../xray/cfg.yaml ../xray/LICENSE ../xray/THIRD-PARTY-LICENSES.txt
-zip aws-xray-daemon-windows-amd64-${VERSION}.zip ../xray-windows-amd64/xray.exe ../xray/cfg.yaml ../xray/LICENSE ../xray/THIRD-PARTY-LICENSES.txt
+cp ../xray-windows-amd64/xray_service.exe xray_service.exe
+zip aws-xray-daemon-windows-amd64-service-${VERSION}.zip xray_service.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray_service.exe
+
+cp ../xray-windows-amd64/xray.exe xray.exe
+zip aws-xray-daemon-windows-amd64-${VERSION}.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+rm xray.exe

--- a/makefile
+++ b/makefile
@@ -19,14 +19,13 @@ release: build test packaging clean-folder
 
 .PHONY: create-folder
 create-folder:
-	mkdir -p build/xray
 	mkdir -p build/dist
 
 .PHONY: copy-file
 copy-file:
-	cp pkg/cfg.yaml build/xray/
-	cp $(BGO_SPACE)/LICENSE build/xray
-	cp $(BGO_SPACE)/THIRD-PARTY-LICENSES.txt build/xray
+	cp pkg/cfg.yaml build/dist/
+	cp $(BGO_SPACE)/LICENSE build/dist
+	cp $(BGO_SPACE)/THIRD-PARTY-LICENSES.txt build/dist
 
 .PHONY: build-mac
 build-mac:

--- a/makefile
+++ b/makefile
@@ -81,31 +81,7 @@ package-rpm:
 # This will be removed in the next major version release
 .PHONY: build-package-legacy
 build-package-legacy:
-	@echo "===Building legacy artifacts with older names==="
-	cd $(BGO_SPACE)/build/dist
-
-	@echo "Building and packaging legacy artifacts for Linux"
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-3.x.zip
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-3.x.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-3.x.deb
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-3.x.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-3.x.deb
-
-	@echo "Building and packaging legacy artifacts for MacOS"
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	cp $(BGO_SPACE)/build/xray-mac-legacy/xray_mac xray_mac
-	zip aws-xray-daemon-macos-3.x.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
-	rm xray_mac
-
-	@echo "Building and packaging legacy artifacts for Windows"
-	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
-	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	cp $(BGO_SPACE)/build/xray-win-legacy/xray.exe xray.exe
-	zip aws-xray-daemon-windows-service-3.x.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
-	rm xray.exe
-	cp $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe xray_windows.exe
-	zip aws-xray-daemon-windows-process-3.x.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
-	rm xray_windows.exe
+	$(BGO_SPACE)/Tool/src/packaging/build-package-legacy.sh
 
 .PHONY: test
 test:

--- a/makefile
+++ b/makefile
@@ -83,29 +83,28 @@ package-rpm:
 build-package-legacy:
 	@echo "===Building legacy artifacts with older names==="
 	cd $(BGO_SPACE)/build/dist
-	LEGACY_VERSION="3.x"
 
 	@echo "Building and packaging legacy artifacts for Linux"
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-${LEGACY_VERSION}.zip
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-${LEGACY_VERSION}.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-${LEGACY_VERSION}.deb
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${LEGACY_VERSION}.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${LEGACY_VERSION}.deb
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-3.x.zip
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-3.x.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-3.x.deb
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-3.x.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-3.x.deb
 
 	@echo "Building and packaging legacy artifacts for MacOS"
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	cp ../xray-mac-legacy/xray_mac xray_mac
-	zip aws-xray-daemon-macos-${LEGACY_VERSION}.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	cp $(BGO_SPACE)/build/xray-mac-legacy/xray_mac xray_mac
+	zip aws-xray-daemon-macos-3.x.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 	rm xray_mac
 
 	@echo "Building and packaging legacy artifacts for Windows"
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	cp ../xray-win-legacy/xray.exe xray.exe
-	zip aws-xray-daemon-windows-service-${LEGACY_VERSION}.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	cp $(BGO_SPACE)/build/xray-win-legacy/xray.exe xray.exe
+	zip aws-xray-daemon-windows-service-3.x.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 	rm xray.exe
-	cp ../xray-win-legacy/xray_windows.exe xray_windows.exe
-	zip aws-xray-daemon-windows-process-${LEGACY_VERSION}.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	cp $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe xray_windows.exe
+	zip aws-xray-daemon-windows-process-3.x.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
 	rm xray_windows.exe
 
 .PHONY: test

--- a/makefile
+++ b/makefile
@@ -79,6 +79,28 @@ package-rpm:
 	$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh amd64
 	$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh arm64
 
+# This will be removed in the next major version release
+build-package-legacy:
+	@echo "===Building legacy artifacts with older names==="
+	cd $(BGO_SPACE)
+
+	@echo "Building and packaging legacy artifacts for Linux"
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-${VERSION}.zip
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-${VERSION}.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-${VERSION}.deb
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${VERSION}.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${VERSION}.deb
+
+	@echo "Building and packaging legacy artifacts for MacOS"
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-macos-${VERSION}.zip $(BGO_SPACE)/build/xray-mac-legacy/xray_mac $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+
+	@echo "Building and packaging legacy artifacts for Windows"
+	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
+	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
+	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-service-${VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-process-${VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+
 .PHONY: test
 test:
 	@echo "Testing daemon"

--- a/makefile
+++ b/makefile
@@ -82,8 +82,8 @@ package-rpm:
 .PHONY: build-package-legacy
 build-package-legacy:
 	@echo "===Building legacy artifacts with older names==="
-	cd $(BGO_SPACE)
-	LEGACY_VERSION=3.x
+	cd $(BGO_SPACE)/build/dist
+	LEGACY_VERSION="3.x"
 
 	@echo "Building and packaging legacy artifacts for Linux"
 	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-${LEGACY_VERSION}.zip
@@ -94,13 +94,19 @@ build-package-legacy:
 
 	@echo "Building and packaging legacy artifacts for MacOS"
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-macos-${VERSION}.zip $(BGO_SPACE)/build/xray-mac-legacy/xray_mac $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+	cp ../xray-mac-legacy/xray_mac xray_mac
+	zip aws-xray-daemon-macos-${LEGACY_VERSION}.zip xray_mac cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	rm xray_mac
 
 	@echo "Building and packaging legacy artifacts for Windows"
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-service-${LEGACY_VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
-	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-process-${LEGACY_VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+	cp ../xray-win-legacy/xray.exe xray.exe
+	zip aws-xray-daemon-windows-service-${LEGACY_VERSION}.zip xray.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	rm xray.exe
+	cp ../xray-win-legacy/xray_windows.exe xray_windows.exe
+	zip aws-xray-daemon-windows-process-${LEGACY_VERSION}.zip xray_windows.exe cfg.yaml LICENSE THIRD-PARTY-LICENSES.txt
+	rm xray_windows.exe
 
 .PHONY: test
 test:

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ path := $(BGO_SPACE):$(WORKSPACE)
 
 build: create-folder copy-file build-mac build-linux-amd64 build-linux-arm64 build-windows
 
-packaging: zip-linux zip-osx zip-win package-rpm package-deb
+packaging: zip-linux zip-osx zip-win package-rpm package-deb build-package-legacy
 
 release: build test packaging clean-folder
 
@@ -80,16 +80,18 @@ package-rpm:
 	$(BGO_SPACE)/Tool/src/packaging/linux/build_rpm_linux.sh arm64
 
 # This will be removed in the next major version release
+.PHONY: build-package-legacy
 build-package-legacy:
 	@echo "===Building legacy artifacts with older names==="
 	cd $(BGO_SPACE)
+	LEGACY_VERSION=3.x
 
 	@echo "Building and packaging legacy artifacts for Linux"
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-${VERSION}.zip
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-${VERSION}.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-${VERSION}.deb
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${VERSION}.rpm
-	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${VERSION}.deb
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-${LEGACY_VERSION}.zip
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-${LEGACY_VERSION}.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-${LEGACY_VERSION}.deb
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${LEGACY_VERSION}.rpm
+	cp $(BGO_SPACE)/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb $(BGO_SPACE)/build/dist/aws-xray-daemon-arm64-${LEGACY_VERSION}.deb
 
 	@echo "Building and packaging legacy artifacts for MacOS"
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-mac-legacy/xray_mac ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
@@ -98,8 +100,8 @@ build-package-legacy:
 	@echo "Building and packaging legacy artifacts for Windows"
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing_windows.go
 	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe ${PREFIX}/cmd/tracing/daemon.go ${PREFIX}/cmd/tracing/tracing.go
-	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-service-${VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
-	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-process-${VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-service-${LEGACY_VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
+	zip $(BGO_SPACE)/build/dist/aws-xray-daemon-windows-process-${LEGACY_VERSION}.zip $(BGO_SPACE)/build/xray-win-legacy/xray_windows.exe $(BGO_SPACE)/build/xray/cfg.yaml $(BGO_SPACE)/build/xray/LICENSE $(BGO_SPACE)/build/xray/THIRD-PARTY-LICENSES.txt
 
 .PHONY: test
 test:


### PR DESCRIPTION
*Description of changes:*
Since the current workflow builds and packages daemon artifacts with names which are different than what are currently officially vended, I'm adding a script to generate the older artifacts in addition to the new ones. We plan to maintain both the names until the next major version release to keep the backward compatibility intact.

PR which introduced new artifact names: https://github.com/aws/aws-xray-daemon/pull/84

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
