### PR TITLE
Info log fix

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -1,0 +1,93 @@
+name: Release build and publish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
+jobs:
+  build_publish_daemon_image:
+    name: Build and Publish X-Ray daemon docker image to docker hub and public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build archives and test
+        run: make build test
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+
+      - name: Build linux archives
+        run: make packaging
+
+      - name: Upload archives as actions artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: distributions
+          path: build/dist/
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build docker image
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            amazon/aws-xray-daemon:${{ github.event.inputs.version }}
+            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 'v${{ github.event.inputs.version }}'
+          release_name: 'AWS X-Ray daemon update v${{ github.event.inputs.version }}'
+          body: 'Please refer [change-log](https://github.com/aws/aws-xray-sdk-go/blob/master/CHANGELOG.md) for more details'
+          draft: true
+          prerelease: false

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -52,12 +52,6 @@ jobs:
         with:
           registry: public.ecr.aws
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -73,9 +67,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64,linux/arm64
-          tags: |
-            amazon/aws-xray-daemon:${{ github.event.inputs.version }}
-            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
+          tags: public.ecr.aws/tghg4/test-ecr:${{ github.event.inputs.version }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build docker image
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           tags: public.ecr.aws/tghg4/test-ecr:${{ github.event.inputs.version }}
           push: true

--- a/pkg/logger/log_config.go
+++ b/pkg/logger/log_config.go
@@ -32,7 +32,7 @@ func LoadLogConfig(writer io.Writer, c *cfg.Config, loglevel string) {
 	case "error":
 		level = log.ErrorLvl
 	case "prod":
-		level = log.InfoLvl
+		level = log.WarnLvl
 	}
 
 	if loglevel != c.Logging.LogLevel {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Set `prod` log level to `warn` level because currently `prod` is set at `info` level which is still more verbose than `warn`

Reference Git issue: https://github.com/aws/aws-xray-daemon/issues/95
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
