### PR TITLE
Change linux service type

### DIFF
--- a/Tool/src/packaging/debian/xray.service
+++ b/Tool/src/packaging/debian/xray.service
@@ -9,7 +9,7 @@ Description=AWS X-Ray Daemon
 After=network-online.target
 
 [Service]
-Type=simple
+Type=exec
 WorkingDirectory=/usr/bin/
 User=xray
 Group=xray

--- a/Tool/src/packaging/linux/xray.service
+++ b/Tool/src/packaging/linux/xray.service
@@ -9,7 +9,7 @@ Description=AWS X-Ray Daemon
 After=network-online.target
 
 [Service]
-Type=simple
+Type=exec
 WorkingDirectory=/usr/bin/
 User=xray
 Group=xray


### PR DESCRIPTION
*Description of changes:*
For systemd, the `simple` service type we were using would always return success to the system manager when running the X-Ray daemon process even if executing the daemon binary wasn't successful. The `exec` type only returns success once the binary is executed successfully, which provides a more expected and explicit failure mode if the binary is not executed successfully.

Source: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Options


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
