### PR TITLE
Bugfix - Adding linux arm64 zip file in legacy packaging

### DIFF
--- a/Tool/src/packaging/build-package-legacy.sh
+++ b/Tool/src/packaging/build-package-legacy.sh
@@ -12,6 +12,7 @@ echo "Building and packaging legacy artifacts for Linux"
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.zip ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-3.x.zip
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-3.x.rpm
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-amd64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-3.x.deb
+cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.zip ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-3.x.zip
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.rpm
 cp ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-arm64-${VERSION}.deb ${BGO_SPACE}/build/dist/aws-xray-daemon-arm64-3.x.deb
 


### PR DESCRIPTION


*Issue #, if available:
As per [documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html) there are 9 binaries with different OS/Arch and we were missing copying/creating linux arm64 daemon zip file

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
