### PR TITLE
Continuous monitoring Dockerhub and public ECR

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -33,12 +33,9 @@ jobs:
           fi
 
       - name: Run daemon image
-        run: docker run --name xray-daemon public.ecr.aws/xray/aws-xray-daemon:latest -n us-west-2 &
-
-      - name: Sleep for 30 seconds
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '30s'
+        run: |
+          docker run --name xray-daemon public.ecr.aws/xray/aws-xray-daemon:latest -n us-west-2 &
+          sleep 30
 
       - name: Publish metrics on daemon startup
         if: ${{ always() }}
@@ -79,12 +76,9 @@ jobs:
           fi
 
       - name: Run daemon image
-        run: docker run --name xray-daemon amazon/aws-xray-daemon:latest -n us-west-2 &
-
-      - name: Sleep for 30 seconds
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '30s'
+        run: |
+          docker run --name xray-daemon amazon/aws-xray-daemon:latest -n us-west-2 &
+          sleep 30
 
       - name: Publish metrics on daemon startup
         if: ${{ always() }}

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -1,0 +1,96 @@
+name: Continuous Monitoring of Dockerhub and public ECR
+on:
+  schedule:
+    - cron:  '0 */6 * * *'
+
+jobs:
+  monitor-ecr:
+    name: Monitor public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+
+      - name: Pull an image from public ECR
+        run: docker pull public.ecr.aws/xray/aws-xray-daemon:latest
+
+      - name: Publish metric on pulling an image
+        if: ${{ always() }}
+        run: |
+          if [[ "$(docker images -q public.ecr.aws/xray/aws-xray-daemon:latest 2> /dev/null)" == "" ]]; then
+            aws cloudwatch put-metric-data --metric-name PullImageFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
+          else
+            aws cloudwatch put-metric-data --metric-name PullImageFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)
+          fi
+
+      - name: Run daemon image
+        run: docker run --name xray-daemon public.ecr.aws/xray/aws-xray-daemon:latest -n us-west-2 &
+
+      - name: Sleep for 30 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+
+      - name: Publish metrics on daemon startup
+        if: ${{ always() }}
+        run: |
+          if [[ "$(docker container inspect -f '{{.State.Status}}' xray-daemon )" != "running" ]]; then
+            aws cloudwatch put-metric-data --metric-name DaemonImageStartupFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
+          else
+            aws cloudwatch put-metric-data --metric-name DaemonImageStartupFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)
+          fi
+
+  monitor-dockerhub:
+    name: Monitor docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Pull an image from docker hub
+        run: docker pull amazon/aws-xray-daemon:latest
+
+      - name: Publish metric on pulling an image
+        if: ${{ always() }}
+        run: |
+          if [[ "$(docker images -q amazon/aws-xray-daemon:latest 2> /dev/null)" == "" ]]; then
+            aws cloudwatch put-metric-data --metric-name PullImageFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
+          else
+            aws cloudwatch put-metric-data --metric-name PullImageFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)
+          fi
+
+      - name: Run daemon image
+        run: docker run --name xray-daemon amazon/aws-xray-daemon:latest -n us-west-2 &
+
+      - name: Sleep for 30 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+
+      - name: Publish metrics on daemon startup
+        if: ${{ always() }}
+        run: |
+          if [[ "$(docker container inspect -f '{{.State.Status}}' xray-daemon )" != "running" ]]; then
+            aws cloudwatch put-metric-data --metric-name DaemonImageStartupFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
+          else
+            aws cloudwatch put-metric-data --metric-name DaemonImageStartupFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)
+          fi

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run daemon image
         run: |
-          docker run --name xray-daemon public.ecr.aws/xray/aws-xray-daemon:latest -n us-west-2 &
+          docker run --name xray-daemon public.ecr.aws/xray/aws-xray-daemon:latest -o -n us-west-2 &
           sleep 30
 
       - name: Publish metrics on daemon startup
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run daemon image
         run: |
-          docker run --name xray-daemon amazon/aws-xray-daemon:latest -n us-west-2 &
+          docker run --name xray-daemon amazon/aws-xray-daemon:latest -o -n us-west-2 &
           sleep 30
 
       - name: Publish metrics on daemon startup

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -15,11 +15,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Login to public ECR
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-
       - name: Pull an image from public ECR
         run: docker pull public.ecr.aws/xray/aws-xray-daemon:latest
 
@@ -56,12 +51,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
 
       - name: Pull an image from docker hub
         run: docker pull amazon/aws-xray-daemon:latest

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -11,17 +11,18 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ACCOUNT }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_ACCOUNT }}
           aws-region: us-east-1
 
       - name: Pull an image from public ECR
+        id: pull-from-ecr
         run: docker pull public.ecr.aws/xray/aws-xray-daemon:latest
 
       - name: Publish metric on pulling an image
         if: ${{ always() }}
         run: |
-          if [[ "$(docker images -q public.ecr.aws/xray/aws-xray-daemon:latest 2> /dev/null)" == "" ]]; then
+          if [[ "${{ steps.pull-from-ecr.outcome }}" == "failure" ]]; then
             aws cloudwatch put-metric-data --metric-name PullImageFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
           else
             aws cloudwatch put-metric-data --metric-name PullImageFailureFromECR --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)
@@ -48,17 +49,18 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ACCOUNT }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_ACCOUNT }}
           aws-region: us-east-1
 
       - name: Pull an image from docker hub
+        id: pull-from-dockerhub
         run: docker pull amazon/aws-xray-daemon:latest
 
       - name: Publish metric on pulling an image
         if: ${{ always() }}
         run: |
-          if [[ "$(docker images -q amazon/aws-xray-daemon:latest 2> /dev/null)" == "" ]]; then
+          if [[ "${{ steps.pull-from-dockerhub.outcome }}" == "failure"  ]]; then
             aws cloudwatch put-metric-data --metric-name PullImageFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 1 --timestamp $(date +%s)
           else
             aws cloudwatch put-metric-data --metric-name PullImageFailureFromDockerhub --dimensions failure=rate --namespace MonitorDaemon --value 0 --timestamp $(date +%s)

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -1,0 +1,93 @@
+name: Release build and publish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
+jobs:
+  build_publish_daemon_image:
+    name: Build and Publish X-Ray daemon docker image to docker hub and public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build archives and test
+        run: make build test
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+
+      - name: Build linux archives
+        run: make packaging
+
+      - name: Upload archives as actions artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: distributions
+          path: build/dist/
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build docker image
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            amazon/aws-xray-daemon:${{ github.event.inputs.version }}
+            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 'v${{ github.event.inputs.version }}'
+          release_name: 'AWS X-Ray daemon update v${{ github.event.inputs.version }}'
+          body: 'Please refer [change-log](https://github.com/aws/aws-xray-sdk-go/blob/master/CHANGELOG.md) for more details'
+          draft: true
+          prerelease: false

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -52,12 +52,6 @@ jobs:
         with:
           registry: public.ecr.aws
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -73,9 +67,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64,linux/arm64
-          tags: |
-            amazon/aws-xray-daemon:${{ github.event.inputs.version }}
-            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
+          tags: public.ecr.aws/tghg4/test-ecr:${{ github.event.inputs.version }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build docker image
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           tags: public.ecr.aws/tghg4/test-ecr:${{ github.event.inputs.version }}
           push: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change introduces continuous monitoring of Dockerhub and public ECR. Based on failure/success it publishes metrics to cloud watch. The purpose of this workflow is to publish metrics so that we can continuously monitoring availability of docker hub and ECR.  Also, we are publishing metrics on pulled daemon image is start-able or not so that we can be well aware about image corruption/security issues with the latest release.

The workflow is scheduled to run every 6 hours.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
