### PR TITLE
Fix: Intermittent pull failure issue

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -14,7 +14,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ACCOUNT }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_ACCOUNT }}
           aws-region: us-east-1
-
+      
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          
       - name: Pull an image from public ECR
         id: pull-from-ecr
         run: docker pull public.ecr.aws/xray/aws-xray-daemon:latest


### PR DESCRIPTION

*Issue #, if available:*
monitor-ecr job of [continuous monitoring workflow](https://github.com/aws/aws-xray-daemon/actions/workflows/continuous-monitoring.yml) fails intermittently with `toomanyrequests: Rate exceeded` so added login to aws account step to avoid such throttling exceptions


*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
