### PR TITLE
Removing -1 suffix from version causing bug

### DIFF
--- a/Tool/src/packaging/debian/build_deb_linux.sh
+++ b/Tool/src/packaging/debian/build_deb_linux.sh
@@ -37,7 +37,6 @@ echo "Package: xray" > ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
 echo "Architecture: ${ARCH}" >> ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
 echo -n "Version: " >> ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
 echo $VERSION >> ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
-echo "-1" >> ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
 cat ${BGO_SPACE}/Tool/src/packaging/debian/control >> ${BGO_SPACE}/bin/debian_${ARCH}/debian/control
 
 echo "Constructing the copyright file"


### PR DESCRIPTION
**Issue**
When trying to install the `aws-xray-daemon-linux-amd64-338157a78c973c312308e7f1ad9b83b233554bc3.deb` from the latest CI build, I got the following error:
```
dpkg: error processing archive distribution_wo_sign/aws-xray-daemon-linux-amd64-338157a78c973c312308e7f1ad9b83b233554bc3.deb (--install):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 3 package 'xray':
 field name '-1' cannot start with hyphen
```

Looking into the debian package, I found the `control` file to like this:
```
Package: xray
Architecture: amd64
Version: 338157a78c973c312308e7f1ad9b83b233554bc3
-1
Section: admin
Depends: libc6
Priority: optional
Copyright: Apache License, Version 2.0
Suggests: aws-xray-doc
Maintainer: Amazon.com, Inc. <aws-xray@amazon.com>
Description: Amazon X-Ray is a platform makes it easy for customers to analyze the behavior of distributed applications.
 Please visit the AWS Developer Tools page for additional information.
```

Notice that the "-1" suffix was supposed to be on the same line as Version but since the version probably ends with a new line character, it's pushed down to a new line which causes parsing error in debian installation. Not sure why the "-1" suffix was even there in the first place. When I checked the 3.2.0 control file, the Version is "3.2.0-1" which doesn't make sense to have the suffix but it worked because the 3.2.0 debian packaging read the Version from a VERSION file and now we read it from enviroment.

*Description of changes:*
- Removing the "-1" suffix while packaging debian.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
