### PR TITLE
check unprocessed segment id is nill

### DIFF
--- a/pkg/processor/batchprocessor.go
+++ b/pkg/processor/batchprocessor.go
@@ -110,7 +110,7 @@ func (s *segmentsBatch) poll() {
 					telemetry.T.SegmentRejected(1)
 					// Print all segments since don't know which exact one is invalid.
 					if unprocessedSegment.Id == nil {
-						log.Debugf("Received invalid unprocessed segment id from X-Ray: %v", unprocessedSegment)
+						log.Debugf("Received nil unprocessed segment id from X-Ray service: %v", unprocessedSegment)
 						log.Debugf("Content in this batch: %v", params)
 						break
 					}

--- a/pkg/processor/batchprocessor_test.go
+++ b/pkg/processor/batchprocessor_test.go
@@ -334,7 +334,7 @@ func TestPollSendReturnUnprocessedInvalid(t *testing.T) {
 
 	assert.EqualValues(t, xRay.CallNoToPutTraceSegments, 1)
 	assert.True(t, strings.Contains(log.Logs[0], fmt.Sprintf("Sent batch of %v segments but had %v Unprocessed segments", 1, 1)))
-	assert.True(t, strings.Contains(log.Logs[1], "Received invalid unprocessed segment id from X-Ray"))
+	assert.True(t, strings.Contains(log.Logs[1], "Received nil unprocessed segment id from X-Ray service"))
 }
 
 type minTestCase struct {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -19,11 +19,11 @@ import (
 	"github.com/aws/aws-xray-daemon/pkg/ringbuffer"
 	"github.com/aws/aws-xray-daemon/pkg/tracesegment"
 
-	"math/rand"
-	"os"
 	"github.com/aws/aws-xray-daemon/pkg/cfg"
 	"github.com/aws/aws-xray-daemon/pkg/conn"
 	"github.com/aws/aws-xray-daemon/pkg/util/timer"
+	"math/rand"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/120

*Description of changes:*
Daemon need to handle the exceptional case that sending invalid format to x-ray, x-ray returns an unprocessed segment with `nil` id. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
