### PR TITLE
revert Info log fix #97

### DIFF
--- a/pkg/logger/log_config.go
+++ b/pkg/logger/log_config.go
@@ -32,7 +32,7 @@ func LoadLogConfig(writer io.Writer, c *cfg.Config, loglevel string) {
 	case "error":
 		level = log.ErrorLvl
 	case "prod":
-		level = log.WarnLvl
+		level = log.InfoLvl
 	}
 
 	if loglevel != c.Logging.LogLevel {


### PR DESCRIPTION
*Issue #, if available:*
In 3.3.0 the default log output level is `Warn`, that suppresses daemon startup log

*Description of changes:*
revert #97 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
