### PR TITLE
Workflow - Publish DockerHub image built on amazonlinux

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -123,15 +123,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build docker image
+      - name: Build docker image for public ECR
         if: ${{ runner.os == 'Linux' }}
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            public.ecr.aws/xray/aws-xray-daemon:alpha
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build docker image for DockerHub
+        if: ${{ runner.os == 'Linux' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.amazonlinux
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |
             amazon/aws-xray-daemon:alpha
-            public.ecr.aws/xray/aws-xray-daemon:alpha
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -5,6 +5,9 @@ on:
       version:
         description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
         required: true
+      major_version:
+        description: The major version to tag the release with, e.g., 1.x, 2.x, 3.x
+        required: true
 
 jobs:
   build_publish_daemon_image:
@@ -101,9 +104,10 @@ jobs:
           tags: |
             amazon/aws-xray-daemon:${{ github.event.inputs.version }}
             amazon/aws-xray-daemon:latest
-            amazon/aws-xray-daemon:3.x
+            amazon/aws-xray-daemon:${{ github.event.inputs.major_version }}
             public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
             public.ecr.aws/xray/aws-xray-daemon:latest
+            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.major_version }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -96,18 +96,30 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build docker image
+      - name: Build docker image for Public ECR
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
+            public.ecr.aws/xray/aws-xray-daemon:latest
+            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.major_version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build docker image for DockerHub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.amazonlinux
           platforms: linux/amd64,linux/arm64
           tags: |
             amazon/aws-xray-daemon:${{ github.event.inputs.version }}
             amazon/aws-xray-daemon:latest
             amazon/aws-xray-daemon:${{ github.event.inputs.major_version }}
-            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.version }}
-            public.ecr.aws/xray/aws-xray-daemon:latest
-            public.ecr.aws/xray/aws-xray-daemon:${{ github.event.inputs.major_version }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-publish-Dockerhub.yml
+++ b/.github/workflows/release-publish-Dockerhub.yml
@@ -29,6 +29,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Build and test
+        run: make build test
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release-publish-Dockerhub.yml
+++ b/.github/workflows/release-publish-Dockerhub.yml
@@ -1,0 +1,61 @@
+name: Build and release DockerHub image
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The complete version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+      major_version:
+        description: The major version to tag the release with, e.g., 2.x, 3.x
+        required: true
+
+jobs:
+  build_publish_DockerHub_image:
+    name: Build X-Ray daemon docker image with amazonlinux base & release to DockerHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.amazonlinux
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            amazon/aws-xray-daemon:${{ github.event.inputs.version }}
+            amazon/aws-xray-daemon:latest
+            amazon/aws-xray-daemon:${{ github.event.inputs.major_version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/pkg/logger/log_config.go
+++ b/pkg/logger/log_config.go
@@ -32,7 +32,7 @@ func LoadLogConfig(writer io.Writer, c *cfg.Config, loglevel string) {
 	case "error":
 		level = log.ErrorLvl
 	case "prod":
-		level = log.WarnLvl
+		level = log.InfoLvl
 	}
 
 	if loglevel != c.Logging.LogLevel {


### PR DESCRIPTION
*Issue #, if available:* #128, #119

*Description of changes:*
- Adding a separate GH workflow to build the daemon image from amazonlinux as base
- Updating the existing workflow to publish `major.x` image tag to public ECR


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
