### PR TITLE
Fixed Dockerfiles regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
 USER xray
-ENTRYPOINT ["/xray"]
+ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
+EXPOSE 2000/udp
+EXPOSE 2000/tcp
+

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -18,4 +18,7 @@ COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
 USER xray
-ENTRYPOINT ["/xray"]
+ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
+EXPOSE 2000/udp
+EXPOSE 2000/tcp
+


### PR DESCRIPTION
*Issue #, if available:*
#135

*Description of changes:*
Adds the binding options for Daemon to listen on all network interfaces, and exposes port 2000 to UDP and TCP traffic, on both Dockerfiles used for ECR & Dockerhub publishing. This will fix a regression with the 3.3.x releases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
