### PR TITLE
Changing copy and entrypoint location for xray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,6 @@ COPY --from=build-env /workspace/xray .
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
-
-RUN mkdir -p /usr/bin/
-RUN ln -s /xray /usr/bin/xray
-
 USER xray
 ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
 EXPOSE 2000/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ COPY --from=build-env /workspace/xray .
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
+
+RUN mkdir -p /usr/bin/
+RUN ln -s /xray /usr/bin/xray
+
 USER xray
 ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
 EXPOSE 2000/udp

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -13,12 +13,12 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN Tool/src/build-in-docker.sh
 
 FROM amazonlinux
-COPY --from=build-env /workspace/xray .
+COPY --from=build-env /workspace/xray /usr/bin/xray
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
 USER xray
-ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
+ENTRYPOINT ["/usr/bin/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
 EXPOSE 2000/udp
 EXPOSE 2000/tcp
 

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -17,6 +17,9 @@ COPY --from=build-env /workspace/xray /usr/bin/xray
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
+
+RUN ln -s /usr/bin/xray /xray
+
 USER xray
 ENTRYPOINT ["/usr/bin/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
 EXPOSE 2000/udp

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -13,15 +13,15 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN Tool/src/build-in-docker.sh
 
 FROM amazonlinux
-COPY --from=build-env /workspace/xray /usr/bin/xray
+COPY --from=build-env /workspace/xray .
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY pkg/cfg.yaml /etc/amazon/xray/cfg.yaml
 
-RUN ln -s /usr/bin/xray /xray
+RUN ln -s /xray /usr/bin/xray
 
 USER xray
-ENTRYPOINT ["/usr/bin/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
+ENTRYPOINT ["/xray", "-t", "0.0.0.0:2000", "-b", "0.0.0.0:2000"]
 EXPOSE 2000/udp
 EXPOSE 2000/tcp
 


### PR DESCRIPTION
A recent issue brought to our notice that the [v3.3.2](https://hub.docker.com/layers/amazon/aws-xray-daemon/3.3.2/images/sha256-5af3311579a9ea50f23677fc6cea0eab7539c866c62905c89862cf902f24c638?context=explore) (3.x and latest as well) DockerHub image diverged from [v3.2.0](https://hub.docker.com/layers/amazon/aws-xray-daemon/3.2.0/images/sha256-b220818a0c4bd0b71224356dfb14eb0b173ae11a00e45aa86e6be9d843f19193?context=explore) and had it's `entrypoint` changed from `/usr/bin/xray` to `/xray`. This caused problem when a user specifically tried to start daemon using the previous entrypoint.

*Description of changes:*
-This PR adds a symlink for entrypoint to `/usr/bin/xray` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
