### PR TITLE
change server listen error log to info

### DIFF
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -133,7 +133,7 @@ func (s *Server) Serve() {
 	log.Infof("Starting proxy http server on %s", s.Addr)
 	err := s.ListenAndServe()
 	if err != nil {
-		log.Errorf("unable to start the server: %v", err)
+		log.Infof("proxy http server has stopped listening: %v", err)
 	}
 }
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -131,9 +131,8 @@ func consume(body io.ReadCloser) (io.ReadSeeker, error) {
 // Serve starts server.
 func (s *Server) Serve() {
 	log.Infof("Starting proxy http server on %s", s.Addr)
-	err := s.ListenAndServe()
-	if err != nil {
-		log.Infof("proxy http server has stopped listening: %v", err)
+	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Errorf("proxy http server failed to listen: %v", err)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#144 

*Description of changes:*
Changes the log-level and wording of the error message when the proxy server stops listening. I also audited other log messages added in #138 but the rest appear to be legitimate errors that should still be logged as such.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
