### PR TITLE
Enforce go1.16.6 as minimum version in actions

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.16.6'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.16.6'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/release-publish-Dockerhub.yml
+++ b/.github/workflows/release-publish-Dockerhub.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.16.6'
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
*Description of changes:*
Currently we are comfortable with taking whatever 1.16.x version is resolved to when publishing the daemon images, however we'd like to have at least Go v1.16.6 for its bug & security fixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
