### PR TITLE
Allow release workflow write access to create GH releases

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -10,7 +10,7 @@ on:
         required: true
 permissions:
   id-token: write
-  contents: read
+  contents: write
 jobs:
   build_publish_daemon_image:
     name: Build X-Ray daemon artifacts and publish docker image to docker hub and public ECR


### PR DESCRIPTION
*Issue #, if available:*
The "Create Release" step in the release workflow [fails](https://github.com/aws/aws-xray-daemon/runs/4599663089?check_suite_focus=true) with `Error: Resource not accessible by integration`. This is because the workflow's permissions for the repository content (includes creating release on the repo) is set to `read` which overwrites the default repo setting. 

*Description of changes:*
Setting the `contents` permission to `write` to enable this workflow to create a draft release. I was able to test this change on my personal repo here: https://github.com/srprash/Workflow_Test/actions/runs/1609080628


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
