### PR TITLE
User-agent redesign - add additional information to user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 3.3.6 (2023-02-01)
+- User-agent redesign - add additional information to user-agent [PR #188](https://github.com/aws/aws-xray-daemon/pull/188)
 - Remove custom backoff logic for sending segments [PR #186](https://github.com/aws/aws-xray-daemon/pull/186)
 
 ## 3.3.5 (2022-09-22)

--- a/pkg/conn/xray_client.go
+++ b/pkg/conn/xray_client.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// Constant prefixes used in to identify information in user-agent
+// Constant prefixes used to identify information in user-agent
 const agentPrefix = "xray-agent/xray-daemon/"
 const execEnvPrefix = " exec-env/"
 const osPrefix = " OS/"

--- a/pkg/conn/xray_client.go
+++ b/pkg/conn/xray_client.go
@@ -11,19 +11,24 @@ package conn
 
 import (
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/aws/aws-xray-daemon/pkg/cfg"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/aws/aws-xray-daemon/pkg/cfg"
 	log "github.com/cihub/seelog"
 )
+
+// Constant prefixes used in to identify information in user-agent
+const agentPrefix = "xray-agent/xray-daemon/"
+const execEnvPrefix = " exec-env/"
+const osPrefix = " OS/"
 
 // XRay defines X-Ray api call structure.
 type XRay interface {
@@ -51,9 +56,16 @@ func NewXRay(awsConfig *aws.Config, s *session.Session) XRay {
 	x := xray.New(s, awsConfig)
 	log.Debugf("Using Endpoint: %s", x.Endpoint)
 
+	execEnv := os.Getenv("AWS_EXECUTION_ENV")
+	if execEnv == "" {
+		execEnv = "UNKNOWN"
+	}
+
+	osInformation := runtime.GOOS + "-" + runtime.GOARCH
+
 	x.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "tracing.XRayVersionUserAgentHandler",
-		Fn:   request.MakeAddToUserAgentHandler("xray", cfg.Version, os.Getenv("AWS_EXECUTION_ENV")),
+		Fn:   request.MakeAddToUserAgentFreeFormHandler(agentPrefix + cfg.Version + execEnvPrefix + execEnv + osPrefix + osInformation),
 	})
 
 	x.Handlers.Sign.PushFrontNamed(request.NamedHandler{


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR reformats the structure of the user-agent string and captures relevant information (agent version, AWS execution environment if any, and OS data) in a uniform format that can be easily parsed. 

Current user-agent: 
```
aws-sdk-go/1.44.62 (go1.19; linux; amd64) exec-env/AWS_ECS_FARGATE xray/3.3.5 (AWS_ECS_FARGATE)
```

New user-agent:
```
aws-sdk-go/1.44.62 (go1.19.5; linux; amd64) xray-agent/xray-daemon/3.3.5 exec-env/UNKNOWN OS/linux-amd64
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
