### PR TITLE
Fix for Dockerfile smell DL3006

### DIFF
--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -12,7 +12,7 @@ RUN adduser -D -u 10001 xray
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN Tool/src/build-in-docker.sh
 
-FROM amazonlinux
+FROM amazonlinux:2023.0.20230322.0
 COPY --from=build-env /workspace/xray .
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Hi!
The Dockerfile placed at "Dockerfile.amazonlinux" contains the best practice violation [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3006 occurs when the image tag for the base image is missing.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the given base image. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag, used by default when pulling the image from DockerHub if a specific image tag is missing.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
