### PR TITLE
Add http2 timouts to close bad TCP connection

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -63,7 +63,7 @@ func getNewHTTPClient(maxIdle int, requestTimeout int, noVerify bool, proxyAddre
 	transport := &http.Transport{
 		MaxIdleConnsPerHost: maxIdle,
 		TLSClientConfig:     tls,
-		IdleConnTimeout:     90 * time.Second, // Should be longer than PutExtensibleTelemetry call frequency: 60 seconds
+		IdleConnTimeout:     90 * time.Second, // Should be longer than PutTelemetryRecords call frequency: 60 seconds
 		Proxy:               http.ProxyURL(proxyURL),
 	}
 

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -11,13 +11,13 @@ package conn
 
 import (
 	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
-	"time"
-	"encoding/json"
-	"io/ioutil"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -63,12 +63,26 @@ func getNewHTTPClient(maxIdle int, requestTimeout int, noVerify bool, proxyAddre
 	transport := &http.Transport{
 		MaxIdleConnsPerHost: maxIdle,
 		TLSClientConfig:     tls,
+		IdleConnTimeout:     90 * time.Second, // Should be longer than PutExtensibleTelemetry call frequency: 60 seconds
 		Proxy:               http.ProxyURL(proxyURL),
 	}
 
 	// is not enabled by default as we configure TLSClientConfig for supporting SSL to data plane.
 	// http2.ConfigureTransport will setup transport layer to use HTTP2
-	http2.ConfigureTransport(transport)
+	h2transport, err := http2.ConfigureTransports(transport)
+	if err != nil {
+		log.Warnf("Failed to configure HTTP2 transport: %v", err)
+	} else {
+		// Adding timeout settings to the http2 transport to prevent bad tcp connection hanging the requests for too long
+		// See: https://t.corp.amazon.com/P104567981
+		// Doc: https://pkg.go.dev/golang.org/x/net/http2#Transport
+		//  - ReadIdleTimeout is the time before a ping is sent when no frame has been received from a connection
+		//  - PingTimeout is the time before the TCP connection being closed if a Ping response is not received
+		// So in total, if a TCP connection goes bad, it would take the combined time before the TCP connection is closed
+		h2transport.ReadIdleTimeout = 1 * time.Second
+		h2transport.PingTimeout = 2 * time.Second
+	}
+
 	http := &http.Client{
 		Transport: transport,
 		Timeout:   time.Second * time.Duration(requestTimeout),


### PR DESCRIPTION
*Issue #, if available:*

During ALB maintainance, there could be cases where the TCP connection from Daemon to X-Ray ALB is not properly closed, the Daemon client will not know the TCP connection is no longer working, and will be kept using it for sending new HTTP2 requests as HTTP2 multplexes all the requests in a single TCP connection, this would results in repeated request timeouts and evetually losing data.

*Description of changes:*


In this change 2 timeouts has been added:

* ReadIdleTimeout time.Duration

        ReadIdleTimeout is the timeout after which a health check using ping frame will be carried out if no frame is received on the connection. Note that a ping response will is considered a received frame, so if there is no other traffic on the connection, the health check will be performed every ReadIdleTimeout interval. If zero, no health check is performed.

 * PingTimeout time.Duration

        PingTimeout is the timeout after which the connection will be closed if a response to Ping is not received. Defaults to 3s (read idle timeout + ping timeout).

So in the case of a TCP connection not being closed properly, the http2 transport would detect there is no frame is being received, then send out a Ping, and if no response is received after the PintTimeout, it would close the connection. Existing pending requests would receive an connection error, which would be retried, and subsequent requests would result in a new connection being created.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
