### PR TITLE
Revert "Release commit v3.3.14 (#224)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-### 3.3.14 (2024-08-19)
-- No major changes since last release. Releasing to update DockerHub image and bring in latest AL2023 image to resolve https://alas.aws.amazon.com/cve/html/CVE-2024-5535.html.
-
 ## 3.3.13 (2024-07-24)
 - Bump Go version to v1.22.4 [PR #222](https://github.com/aws/aws-xray-daemon/pull/222)
 


### PR DESCRIPTION
This reverts commit 56f6ee2e4fdacce34cbb9d692918f54dcfa2f936.

We will update DockerHub image without upgrading Daemon Version. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
