### PR TITLE
upgrade golang to 1.23.6

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.22.4'
+          go-version: '^1.23.6'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.22.4'
+          go-version: '^1.23.6'
 
       - uses: actions/cache@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.22.4-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.23.6-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.22.4-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.23.6-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/Tool/src/packaging/linux/build_rpm_linux.sh
+++ b/Tool/src/packaging/linux/build_rpm_linux.sh
@@ -38,7 +38,7 @@ cp ${BGO_SPACE}/THIRD-PARTY-LICENSES.txt ${BGO_SPACE}/bin/linux_${ARCH}/linux/et
 echo "Creating the rpm package"
 SPEC_FILE="${BGO_SPACE}/Tool/src/packaging/linux/xray.spec"
 BUILD_ROOT="${BGO_SPACE}/bin/linux_${ARCH}/linux"
-rpmbuild --target ${BUILD_ARCH}-linux --define "rpmversion ${VERSION}" --define "_topdir bin/linux_${ARCH}/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
+rpmbuild --target ${BUILD_ARCH}-linux --define "rpmver ${VERSION}" --define "_topdir bin/linux_${ARCH}/linux/rpmbuild" -bb --buildroot ${BUILD_ROOT} ${SPEC_FILE}
 
 echo "Copying rpm files to bin"
 cp ${BGO_SPACE}/bin/linux_${ARCH}/linux/rpmbuild/RPMS/${BUILD_ARCH}/*.rpm ${BGO_SPACE}/build/dist/aws-xray-daemon-linux-${ARCH}-${VERSION}.rpm

--- a/Tool/src/packaging/linux/xray.spec
+++ b/Tool/src/packaging/linux/xray.spec
@@ -1,5 +1,5 @@
 Name:		xray
-Version:	%rpmversion
+Version:	%rpmver
 Release:	1
 Summary:	X-Ray daemon
 


### PR DESCRIPTION
*Issue #, if available:*
Addressing CVEs:
* 2024-34156
* 2024-34155
* 2024-34158
These CVEs affect Go versions before go1.22.7, from go1.23.0-0 before go1.23.1

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
