### PR TITLE
Use actions/download-artifact@v4

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: distributions
           path: distributions


### PR DESCRIPTION
*Issue #, if available:*
Use actions/download-artifact@v4.

v3 is Deprecated - https://github.com/aws/aws-xray-daemon/actions/runs/13291457159

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
