### PR TITLE
[Bld Break Fix] Upgrade actions/cache to v4 in release build

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: '^1.24.2'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -88,7 +88,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
The release build was broken because GitHub no longer supports actions/cache@v2.

This fix upgrades it to v4 in the release build workflow YAML file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
