### PR TITLE
Upgrade Ubuntu image for integration test

### DIFF
--- a/testing/terraform/amis.tf
+++ b/testing/terraform/amis.tf
@@ -17,9 +17,9 @@ variable "ami_family" {
 
 variable "amis" {
   default = {
-    ubuntu18 = {
+    ubuntu22 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*"
       ami_owner          = "099720109477"
       ami_id             = "ami-02da34c96f69d525c"
       ami_product_code   = []

--- a/testing/terraform/testcases/linux_deb.tfvars
+++ b/testing/terraform/testcases/linux_deb.tfvars
@@ -1,4 +1,4 @@
-testing_ami = "ubuntu18"
+testing_ami = "ubuntu22"
 daemon_file_name = "aws-xray-daemon-3.x.deb"
 daemon_install_command = "sudo dpkg -i aws-xray-daemon-3.x.deb"
 daemon_start_command = "sudo /usr/bin/xray -a start"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Integration test job for Linux Debian system is failing in master branch due to dropped support for Ubuntu 18 image. Update image to 22.04 to pass test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
