### PR TITLE
update TestEC2Session unit test name

### DIFF
--- a/pkg/conn/conn_test.go
+++ b/pkg/conn/conn_test.go
@@ -285,8 +285,8 @@ func TestGetProxyURL(t *testing.T) {
 	assert.Nil(t, proxyURL)
 }
 
-// TestEC2Session tests fetching region value from ec2 metadata service
-func TestEC2Session(t *testing.T) {
+// TestGetAWSConfigEC2Region tests fetching region value from ec2 metadata service
+func TestGetAWSConfigEC2Region(t *testing.T) {
 	env := stashEnv()
 	defer popEnv(env)
 


### PR DESCRIPTION
## What does this pull request do?
Quick PR update unit test name to be more accurate to what it is now testing.

https://github.com/aws/aws-xray-daemon/pull/247#discussion_r2317348844


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
