### PR TITLE
incorrect endpoint logging format in debug output

### DIFF
--- a/pkg/conn/xray_client.go
+++ b/pkg/conn/xray_client.go
@@ -93,7 +93,11 @@ func NewXRay(cfg aws.Config) XRay {
 		})
 	})
 
-	log.Debugf("Using Endpoint: %s", cfg.BaseEndpoint)
+	if cfg.BaseEndpoint != nil {
+		log.Debugf("Using Endpoint: %s", *cfg.BaseEndpoint)
+	} else {
+		log.Debug("Using default X-Ray endpoint")
+	}
 
 	return &XRayClient{
 		xRay: x,


### PR DESCRIPTION
### What does this pull request do?

Fixes a logging bug where the daemon's debug output displays %!s(*string=<nil>) instead of properly handling the endpoint value.

During the AWS SDK v1 → v2 migration, the endpoint field changed from a string to a *string (pointer). The logging code wasn't updated to handle this type change, causing Go's formatter to display the malformed output when the endpoint is nil.

```
Using Endpoint: %!s(*string=<nil>)
```

SDK v1: `x.Endpoint (string)` SDK v2: `cfg.BaseEndpoint (*string)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
