### PR TITLE
Fix IMDS queries under proxies

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -158,7 +158,7 @@ func GetAWSConfig(ctx context.Context, cn connAttr, c *daemoncfg.Config, roleArn
 	} else if !noMetadata {
 		awsRegion = getRegionFromECSMetadata()
 		if awsRegion == "" {
-			tempCfg, err := getDefaultConfig(ctx)
+			tempCfg, err := GetDefaultConfig(ctx)
 			if err == nil {
 				awsRegion, err = cn.getEC2Region(ctx, tempCfg)
 				if err != nil {
@@ -171,7 +171,7 @@ func GetAWSConfig(ctx context.Context, cn connAttr, c *daemoncfg.Config, roleArn
 			}
 		}
 	} else {
-		tempCfg, err := getDefaultConfig(ctx)
+		tempCfg, err := GetDefaultConfig(ctx)
 		if err == nil {
 			awsRegion = tempCfg.Region
 			log.Debugf("Fetched region %s from config", awsRegion)
@@ -234,11 +234,11 @@ func ProxyServerTransport(config *daemoncfg.Config) *http.Transport {
 
 func (c *Conn) newAWSConfig(ctx context.Context, roleArn string, region string) (aws.Config, error) {
 	if roleArn == "" {
-		return getDefaultConfig(ctx)
+		return GetDefaultConfig(ctx)
 	}
 
 	// Load config with STS credentials
-	cfg, err := getDefaultConfig(ctx)
+	cfg, err := GetDefaultConfig(ctx)
 	if err != nil {
 		return aws.Config{}, err
 	}
@@ -255,7 +255,7 @@ func (c *Conn) newAWSConfig(ctx context.Context, roleArn string, region string) 
 	return cfg, nil
 }
 
-func getDefaultConfig(ctx context.Context) (aws.Config, error) {
+func GetDefaultConfig(ctx context.Context) (aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return aws.Config{}, err

--- a/pkg/conn/conn_test.go
+++ b/pkg/conn/conn_test.go
@@ -242,7 +242,7 @@ func TestGetEC2Region(t *testing.T) {
 	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 
 	c := &Conn{}
-	cfg, _ := getDefaultConfig(context.Background())
+	cfg, _ := GetDefaultConfig(context.Background())
 
 	// This should fail when IMDS is disabled or not on EC2
 	region, err := c.getEC2Region(context.Background(), cfg)
@@ -254,7 +254,7 @@ func TestGetEC2Region(t *testing.T) {
 	}
 }
 
-// TestGetDefaultConfig tests that getDefaultConfig returns a valid config
+// TestGetDefaultConfig tests that GetDefaultConfig returns a valid config
 func TestGetDefaultConfig(t *testing.T) {
 	env := stashEnv()
 	defer popEnv(env)
@@ -264,7 +264,7 @@ func TestGetDefaultConfig(t *testing.T) {
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
 	os.Setenv("AWS_REGION", "us-west-2")
 
-	cfg, err := getDefaultConfig(context.Background())
+	cfg, err := GetDefaultConfig(context.Background())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -174,7 +174,12 @@ func newT(ctx context.Context, cfg aws.Config, resourceARN string, noMetadata bo
 
 	var metadataClient *imds.Client
 	if !noMetadata {
-		metadataClient = imds.NewFromConfig(cfg)
+		tempCfg, err := conn.GetDefaultConfig(ctx)
+		if err != nil {
+			log.Debugf("Init metadata client failed: %s", err)
+		} else {
+			metadataClient = imds.NewFromConfig(tempCfg)
+		}
 	}
 
 	hostnameEnv := os.Getenv("AWS_HOSTNAME")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/255

*Description of changes:*
1. Use the default config to call IMDS in the telemetry.

Before the fix:
```
export HTTP_PROXY=http://api.example.com
export HTTPS_PROXY=https://api.example.com
export NO_PROXY="169.254.169.254,localhost,127.0.0.1"
./xray -o -n us-east-1 --log-level=debug --local-mode=false

2025-09-14T06:31:52Z [Debug] Get hostname metadata failed: operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/hostname": proxyconnect tcp: dial tcp: lookup api.example.com on 172.31.0.2:53: no such host
2025-09-14T06:31:52Z [Error] Get instance id metadata failed: operation error ec2imds: GetMetadata, request send failed, Get "http://169.254.169.254/latest/meta-data/instance-id": proxyconnect tcp: dial tcp: lookup api.example.com on 172.31.0.2:53: no such host
```

After the fix:
```
export HTTP_PROXY=http://api.example.com
export HTTPS_PROXY=https://api.example.com
export NO_PROXY="169.254.169.254,localhost,127.0.0.1"
./xray-v1 -o -n us-east-1 --log-level=debug --local-mode=false

2025-09-14T06:36:58Z [Debug] Using ip-xxx.ec2.internal hostname for telemetry records
2025-09-14T06:36:58Z [Debug] Using i-xxx Instance Id for Telemetry records
2025-09-14T06:36:58Z [Debug] Using default X-Ray endpoint
2025-09-14T06:36:58Z [Debug] Telemetry initiated
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
