### PR TITLE
Bump up Go from 1.24.1 to 1.24.9

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.24.2'
+          go-version: '^1.24.9'
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.24.2'
+          go-version: '^1.24.9'
 
       - uses: actions/cache@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.24.9-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.24.9-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-xray-daemon
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0


### PR DESCRIPTION
Bump up Go toolchain to address 14 vulnerabilities from Go standard library.

Your code is affected by 14 vulnerabilities from the Go standard library. 
https://github.com/lukeina2z/aws-xray-daemon/actions/runs/19117436931/job/54629960434

GO-2025-4015
GO-2025-4014
GO-2025-4013
GO-2025-4012
GO-2025-4011

GO-2025-4010
GO-2025-4009
GO-2025-4008
GO-2025-4007
GO-2025-3956

GO-2025-3751
GO-2025-3750
GO-2025-3749
GO-2025-3563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
