### PR TITLE
bump Go from 1.25.9 to 1.25.10

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 #v2.2.0
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-xray-daemon
 
 go 1.23.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump Go to 1.25.10 to resolve the following stdlib CVEs:

CVE-2026-33811
CVE-2026-33814
CVE-2026-39820
CVE-2026-39836
CVE-2026-42499

Failing daily scan: https://github.com/aws/aws-xray-daemon/actions/runs/25737248345/job/75577453558

Go 1.25.10 fixes: https://github.com/golang/go/issues?q=milestone%3AGo1.25.10+label%3ACherryPickApproved

Tested by rebuilding and running tests, and rescanned package locally (no HIGH CVEs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.