### PR TITLE
bump Go to 1.25.11

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 #v2.2.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine AS build-env
 ARG TARGETPLATFORM
 
 RUN apk update && apk add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-xray-daemon
 
 go 1.23.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.10 to 1.25.11 to address security vulnerabilities:
  - **CVE-2026-42504** — `mime`: quadratic complexity in `WordDecoder.DecodeHeader` (DoS)
  - **CVE-2026-42507** — `net/textproto`: arbitrary input included in errors without escaping (log injection)
  - **CVE-2026-27145** — `crypto/x509`: quadratic complexity in `VerifyHostname` (DoS)
- Updated go.mod toolchain, Dockerfiles, and CI workflows