### PR TITLE
fix RHEL AMI search pattern for integration tests

### DIFF
--- a/testing/terraform/amis.tf
+++ b/testing/terraform/amis.tf
@@ -39,9 +39,9 @@ variable "amis" {
     }
     redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.6.0_HVM*"
+      ami_search_pattern = "RHEL-8.10.0_HVM*"
       ami_owner          = "309956199498"
-      ami_id             = "ami-087c2c50437d0b80d"
+      ami_id             = "ami-03b954790bda69a2e"
       ami_product_code   = []
       family             = "linux"
       arch               = "x86_64"


### PR DESCRIPTION
## Summary
- RHEL 8.6 AMIs have been decommissioned by Red Hat, causing integration test (`linux_rpm`) to fail with "Your query returned no results"
- Update AMI search pattern from `RHEL-8.6.0_HVM*` to `RHEL-8.10.0_HVM*`