### PR TITLE
bump Go to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-xray-daemon
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.25.11 to 1.25.12 to remediate CVE-2026-39822 (os.Root symlink following vulnerability allowing directory traversal)
- Complements #291 which addressed the golang.org/x/net CVEs

## Test plan
- [x] `go build ./...` passes locally
- [x] `go test ./...` all tests pass
- [x] `trivy fs --detection-priority comprehensive --severity HIGH,CRITICAL` reports 0 vulnerabilities