### PR TITLE
Remove orphaned tag-alias-check job left by #294 merge

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -109,25 +109,3 @@ jobs:
       - name: Download and verify S3 assets
         if: ${{ always() }}
         run: .github/scripts/monitor-s3-assets.sh
-
-  tag-alias-check:
-    name: Check tag aliases
-    runs-on: ubuntu-latest
-    # Verifies the moving aliases (latest, 3.x) resolve to the current release
-    # across ECR, Docker Hub, and S3, so a stale alias can't silently serve an
-    # old version. Lightweight (HEAD/manifest requests only), so it fits the
-    # 10-minute cadence alongside the other jobs.
-    timeout-minutes: 5
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
-        with:
-          role-to-assume: ${{ secrets.AWS_INTEG_TEST_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Check tag aliases
-        if: ${{ always() }}
-        run: .github/scripts/check-tag-aliases.sh


### PR DESCRIPTION
## Problem

PR #294 was scoped down to just the S3 download+signature monitor before merge, which deleted `.github/scripts/check-tag-aliases.sh`. The squash-merge kept the file deletion but **not** the corresponding removal of the `tag-alias-check` job from `continuous-monitoring.yml`.

As a result, `master` has a `tag-alias-check` job that runs `.github/scripts/check-tag-aliases.sh` — a file that no longer exists — so **the job fails on every scheduled run** (`No such file or directory`). Confirmed on a post-merge `workflow_dispatch` run.

## Fix

Remove the orphaned job block. The referenced script is already gone; the `monitor-ecr`, `monitor-dockerhub`, and `monitor-s3` jobs are unaffected.

## Verification

- `continuous-monitoring.yml` now defines exactly three jobs: `monitor-ecr`, `monitor-dockerhub`, `monitor-s3`.
- `monitor-s3-assets.sh` (the actual S3 monitor) is present and unchanged.